### PR TITLE
Optimize item loc container copy

### DIFF
--- a/rando/ItemLocContainer.py
+++ b/rando/ItemLocContainer.py
@@ -70,12 +70,10 @@ class ItemLocContainer(object):
                                locs)
         ret.currentItems = self.currentItems[:]
         ret.unrestrictedItems = copy.copy(self.unrestrictedItems)
-        for il in self.itemLocations:
-            ilCpy = {
-                'Item': il['Item'],
-                'Location': copy.deepcopy(il['Location'])
-            }
-            ret.itemLocations.append(ilCpy)
+        ret.itemLocations = [ {
+            'Item': il['Item'],
+            'Location': copy.deepcopy(il['Location'])
+        } for il in self.itemLocations ]
         ret.sm.addItems([item['Type'] for item in ret.currentItems])
         return ret
 

--- a/rando/ItemLocContainer.py
+++ b/rando/ItemLocContainer.py
@@ -62,7 +62,7 @@ class ItemLocContainer(object):
         return eq
 
     def __copy__(self):
-        locs = [copy.deepcopy(loc) for loc in self.unusedLocations]
+        locs = copy.deepcopy(self.unusedLocations)
         # we don't copy restriction state on purpose: it depends on
         # outside context we don't want to bring to the copy
         ret = ItemLocContainer(SMBoolManager(),


### PR DESCRIPTION
By far, the most expensive operation in generating a seed is the copying of `ItemLocContainer` objects.  In a typical SMRAT seed, it only gets called 100 times, but accounts for 70% of the total runtime.  The problem is primarily the large number of calls to `deepcopy` (in one seed I measured 5 million invocations).

Ideally we would do a shallow copy instead of a deep copy, but since item and location dicts are mutable, it is hard to guarantee that switching to a shallow copy doesn't change behavior.  We can get a pretty big speedup by reducing the number of calls to `deepcopy`, changing `ItemLocContainer.__copy__` to call `deepcopy` once instead of in a list comprehension.

A smaller optimization to `ItemLocContainer.__copy__` is also possible: the function creates a list by calling `list.append` in a loop, but a list comprehension reduces the total number of allocations, since the list doesn't need to be resized.

Overall I've measured these two changes to improve performance by 30-40%, depending on the seed.