### PR TITLE
graph: optimize getPathDifficulty

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -219,15 +219,16 @@ class AccessGraph(object):
         return path
 
     def getPathDifficulty(self, path, availAps):
-        pdiff = SMBool(True, 0)
+        difficulty = 0
+        knows = set()
+        items = [ ]
         for ap in path:
             diff = availAps[ap]['difficulty']
-            pdiff = SMBool(True,
-                           difficulty=max(pdiff.difficulty, diff.difficulty),
-                           knows=list(set(pdiff.knows + diff.knows)),
-                           items=pdiff.items + diff.items)
+            difficulty = max(difficulty, diff.difficulty)
+            knows.update(diff.knows)
+            items.extend(diff.items)
 
-        return pdiff
+        return SMBool(True, difficulty, list(knows), items)
 
     def getAvailAPPaths(self, availAccessPoints, locsAPs):
         paths = {}


### PR DESCRIPTION
Optimized getPathDifficulty by eliminating unnecessary temporaries.
Instead of creating an additional 1 SMBool, 1 set, and 2 lists each time
through the loop, we now create 1 list, 1 set, and 1 SMBool for the whole
function.

This improves performance by ~5% in testing.