### PR TITLE
Lazy smbool

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -228,13 +228,13 @@ class AccessGraph(object):
 
     def getPathDifficulty(self, path, availAps):
         difficulty = 0
-        knows = set()
+        knows = [ ]
         items = [ ]
         for ap in path:
             diff = availAps[ap]['difficulty']
             difficulty = max(difficulty, diff.difficulty)
-            knows.update(diff.knows)
-            items.extend(diff.items)
+            knows = [ knows, diff._knows ]
+            items = [ items, diff._items ]
 
         return SMBool(True, difficulty, list(knows), items)
 
@@ -410,14 +410,14 @@ class AccessGraphSolver(AccessGraph):
         # loc diff: tdiff + diff
         locDiff = SMBool(diff.bool,
                          difficulty=max(tdiff.difficulty, diff.difficulty),
-                         knows=list(set(tdiff.knows + diff.knows)),
-                         items=tdiff.items + diff.items)
+                         knows=[tdiff._knows, diff._knows],
+                         items=[tdiff._items, diff._items])
 
         # total diff: loc diff + pdiff
         allDiff = SMBool(diff.bool,
                          difficulty=max(locDiff.difficulty, pdiff.difficulty),
-                         knows=list(set(locDiff.knows + pdiff.knows)),
-                         items=locDiff.items + pdiff.items)
+                         knows=[locDiff._knows, pdiff._knows],
+                         items=[locDiff._items, pdiff._items])
 
         return (allDiff, locDiff)
 
@@ -425,6 +425,6 @@ class AccessGraphRando(AccessGraph):
     def computeLocDiff(self, tdiff, diff, pdiff):
         allDiff = SMBool(diff.bool,
                          difficulty=max(tdiff.difficulty, diff.difficulty, pdiff.difficulty),
-                         knows=list(set(tdiff.knows + diff.knows + pdiff.knows)),
-                         items=tdiff.items + diff.items + pdiff.items)
+                         knows=[tdiff._knows, diff._knows, pdiff._knows],
+                         items=[tdiff._items, diff._items, pdiff._items])
         return (allDiff, None)

--- a/graph_locations.py
+++ b/graph_locations.py
@@ -76,7 +76,7 @@ class Location:
 
     def __copy__(self):
         d = self.difficulty
-        difficulty = SMBool(d.bool, d.difficulty, d.knows, d.items) if d is not None else None
+        difficulty = SMBool(d.bool, d.difficulty, d._knows, d._items) if d is not None else None
         ret = type(self)(
             self.distance, self.accessPoint, difficulty, self.path,
             self.pathDifficulty, self.locDifficulty, self.restricted,

--- a/helpers.py
+++ b/helpers.py
@@ -39,6 +39,7 @@ class Helpers(object):
 
         if result == True:
             result.knows = [hellRunName+'HellRun']
+
         return result
 
     # gives damage reduction factor with the current suits
@@ -85,7 +86,7 @@ class Helpers(object):
         if result == True:
             result.knows = ['HardRoom-'+roomName]
             if dmgRed != 1.0:
-                result.items += items
+                result._items.append(items)
         return result
 
     @Cache.decorator
@@ -125,7 +126,7 @@ class Helpers(object):
             if hellRun != 'LowerNorfair':
                 ret = self.energyReserveCountOkHellRun(hellRun, mult)
                 if ret.bool == True:
-                    ret.items += items
+                    ret._items.append(items)
                 return ret
             else:
                 tanks = self.energyReserveCount()
@@ -138,10 +139,10 @@ class Helpers(object):
                 if ret.bool == True:
                     if sm.haveItem('Gravity') == True:
                         ret.difficulty *= 0.7
-                        ret.items.append('Gravity')
+                        ret._items.append('Gravity')
                     elif sm.haveItem('ScrewAttack') == True:
                         ret.difficulty *= 0.7
-                        ret.items.append('ScrewAttack')
+                        ret._items.append('ScrewAttack')
                 #nPB = self.smbm.itemCount('PowerBomb')
                 #print("canHellRun LN. tanks=" + str(tanks) + ", nCF=" + str(nCF) + ", nPB=" + str(nPB) + ", mult=" + str(mult) + ", heatProof=" + str(isHeatProof.bool) + ", ret=" + str(ret))
                 return ret
@@ -487,7 +488,7 @@ class Helpers(object):
         else:
             fight = sm.wor(sm.energyReserveCountOk(math.ceil(4/sm.getDmgReduction(envDmg=False)[0])),
                            sm.knowsLowStuffBotwoon())
-            return SMBool(fight.bool, max(diff, fight.difficulty), items=items+fight.items, knows=knows+fight.knows)
+            return SMBool(fight.bool, max(diff, fight.difficulty), items=items+fight._items, knows=knows+fight._knows)
 
     @Cache.decorator
     def enoughStuffGT(self):
@@ -506,7 +507,7 @@ class Helpers(object):
         else:
             fight = sm.wor(sm.energyReserveCountOk(math.ceil(8/sm.getDmgReduction(envDmg=False)[0])),
                            sm.knowsLowStuffGT())
-            return SMBool(fight.bool, max(diff, fight.difficulty), items=items+fight.items, knows=knows+fight.knows)
+            return SMBool(fight.bool, max(diff, fight.difficulty), items=items+fight._items, knows=knows+fight._knows)
 
     @Cache.decorator
     def enoughStuffsRidley(self):
@@ -563,7 +564,7 @@ class Helpers(object):
             if sm.haveItem('Gravity') == False:
                 fight.difficulty *= Settings.algoSettings['draygonNoGravityMalus']
             else:
-                fight.items.append('Gravity')
+                fight._items.append('Gravity')
             if not sm.haveItem('Morph'):
                 fight.difficulty *= Settings.algoSettings['draygonNoMorphMalus']
             if sm.haveItem('Gravity') and sm.haveItem('ScrewAttack'):

--- a/smbool.py
+++ b/smbool.py
@@ -15,7 +15,7 @@ class SMBool:
 
     @property
     def knows(self):
-        self._knows = flatten(self._knows)
+        self._knows = list(set(flatten(self._knows)))
         return self._knows
 
     @knows.setter
@@ -24,7 +24,7 @@ class SMBool:
 
     @property
     def items(self):
-        self._items = flatten(self._items)
+        self._items = list(set(flatten(self._items)))
         return self._items
 
     @items.setter
@@ -73,8 +73,8 @@ class SMBool:
         else:
             return SMBool(True,
                           sum([smb.difficulty for smb in args]),
-                          [know for smb in args for know in smb.knows],
-                          [item for smb in args for item in smb.items])
+                          [ smb._knows for smb in args ],
+                          [ smb._items for smb in args ])
 
     def wor(*args):
         if True in args:

--- a/smbool.py
+++ b/smbool.py
@@ -1,11 +1,35 @@
+def flatten(l):
+    if type(l) is list:
+        return [ y for x in l for y in flatten(x) ]
+    else:
+        return [ l ]
+
 # super metroid boolean
 class SMBool:
-    __slots__ = ('bool', 'difficulty', 'knows', 'items')
+    __slots__ = ('bool', 'difficulty', '_knows', '_items')
     def __init__(self, boolean, difficulty=0, knows=[], items=[]):
         self.bool = boolean
         self.difficulty = difficulty
-        self.knows = knows
-        self.items = items
+        self._knows = knows
+        self._items = items
+
+    @property
+    def knows(self):
+        self._knows = flatten(self._knows)
+        return self._knows
+
+    @knows.setter
+    def knows(self, knows):
+        self._knows = knows
+
+    @property
+    def items(self):
+        self._items = flatten(self._items)
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        self._items = items
 
     def __repr__(self):
         # to display the smbool as a string


### PR DESCRIPTION
This introduces lazy-evaluation of knows and items in SMBool.  Externally, they both appear to have the same value they had previously, but internally, they are arbitrarily-nested lists.  This allows them to continue to be tracked, but without the overhead of list concatenation when the values are not needed.