### PR TITLE
Cleanup cache

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -7,9 +7,9 @@ class Debug_MasterCache(dict):
         ret = dict.get(self, newKey, NotFound)
         if ret is not NotFound:
             print("usek: "+format(newKey, '#067b'))
-            if Cache.masterCache[newKey]['key'] != newKey:
+            if Cache.masterCache[newKey].key != newKey:
                 print("ERROR: key stored in cache is not the same as the new key !!!!")
-                print("      "+format(self[newKey]['key'], '#067b')+" key in cache")
+                print("      "+format(self[newKey].key, '#067b')+" key in cache")
             return ret
         else:
             return default
@@ -19,35 +19,44 @@ class Debug_MasterCache(dict):
         if newKey != 0:
             print("newk: "+format(newKey, '#067b'))
 
-class Debug_Cache(dict):
-    def get(self, name, default):
-        ret = dict.get(self, name, NotFound)
-        if ret is not NotFound:
-            if name in Cache.funcs:
-                print("cache found for {}: {}".format(name, self[name]))
+class Debug_Cache(list):
+    def __init__(self, key, size):
+        list.__init__(self, [ None ] * size)
+        self.key = key
+
+    def __getitem__(self, slot):
+        ret = list.__getitem__(self, slot)
+        if ret is not None:
+            if slot in Cache.debug_slots:
+                name = Cache.debug_slots[slot]
+                print("cache found for {}: {}".format(name, ret))
             return ret
         else:
-            return default
+            return None
 
-    def __setitem__(self, name, value):
-        dict.__setitem__(self, name, value)
-        if name != 'key' and name in Cache.funcs:
-            print("cache added for {}: {}".format(name, self[name]))
+    def __setitem__(self, slot, value):
+        list.__setitem__(self, slot, value)
+        if slot in Cache.debug_slots:
+            name = Cache.debug_slots[slot]
+            print("cache added for {}: {}".format(name, value))
 
-    def validate(self, name, ret):
-        if ret != self[name]:
-            print("ERROR: cache ({}) != current ({}) for {}".format(self[name], ret, name))
+    def validate(self, name, slot, ret):
+        value_in_cache = list.__getitem__(self, slot)
+        if ret != value_in_cache:
+            print("ERROR: cache ({}) != current ({}) for {}".format(value_in_cache, ret, name))
 
 class VersionedCache(object):
-    __slots__ = ( 'cache', 'masterCache', 'funcs', 'lambdas', 'debug', 'key' )
+    __slots__ = ( 'cache', 'masterCache', 'debug', 'key', 'next_slot',
+    'debug_slots', 'size' )
 
     def __init__(self):
-        self.cache = {}
+        self.cache = []
         self.masterCache = {}
-        self.funcs = set()
-        self.lambdas = set()
         self.debug = False
         self.key = None
+        self.next_slot = 0
+        self.debug_slots = { }
+        self.size = 0
 
     def reset(self):
         # reinit the whole cache
@@ -59,7 +68,7 @@ class VersionedCache(object):
             return
         cache = self.masterCache.get(newKey, None)
         if cache is None:
-            cache = Debug_Cache(key=newKey) if self.debug else { }
+            cache = Debug_Cache(newKey, self.size) if self.debug else [ None ] * self.size
             self.masterCache[newKey] = cache
             self.cache = cache
             self.key = newKey
@@ -69,28 +78,35 @@ class VersionedCache(object):
 
     def decorator(self, func):
         name = func.__name__
-        self.funcs.add(name)
-        return self._decorate(name, func)
+        slot = self._new_slot(name)
+        self.debug_slots[slot] = name
+        return self._decorate(name, slot, func)
 
     # for lambdas
     def ldeco(self, name, func):
-        self.lambdas.add(name)
-        return self._decorate(name, func)
+        slot = self._new_slot(name)
+        return self._decorate(name, slot, func)
 
-    def _decorate(self, name, func):
+    def _new_slot(self, name):
+        slot = self.next_slot
+        self.next_slot += 1
+        self.size += 1
+        return slot
+
+    def _decorate(self, name, slot, func):
         def _decorator(arg):
-            ret = self.cache.get(name, None)
+            ret = self.cache[slot]
             if ret is not None:
                 # TODO: Commented-out, because this function can get
                 # called 500K times or more during a run, and so this
                 # conditional measurably affects performance.
-                # if self.debug and name in self.funcs:
+                # if self.debug and slot in self.debug_slots:
                 #     ret = func(arg)
-                #     self.cache.validate(name, ret)
+                #     self.cache.validate(name, slot, ret)
                 return ret
             else:
                 ret = func(arg)
-                self.cache[name] = ret
+                self.cache[slot] = ret
                 return ret
         return _decorator
 

--- a/cache.py
+++ b/cache.py
@@ -39,6 +39,8 @@ class Debug_Cache(dict):
             print("ERROR: cache ({}) != current ({}) for {}".format(self[name], ret, name))
 
 class VersionedCache(object):
+    __slots__ = ( 'cache', 'masterCache', 'funcs', 'lambdas', 'debug' )
+
     def __init__(self):
         self.cache = {}
         self.masterCache = {}

--- a/cache.py
+++ b/cache.py
@@ -1,51 +1,93 @@
 # the caching decorator for helpers functions
 
+class NotFound: pass
+
+class Debug_MasterCache(dict):
+    def __contains__(self, newKey):
+        has_newKey = dict.__contains__(self, newKey)
+        if has_newKey:
+            print("usek: "+format(newKey, '#067b'))
+            if Cache.masterCache[newKey]['key'] != newKey:
+                print("ERROR: key stored in cache is not the same as the new key !!!!")
+                print("      "+format(self[newKey]['key'], '#067b')+" key in cache")
+        return has_newKey
+
+    def __setitem__(self, newKey, value):
+        dict.__setitem__(self, newKey, value)
+        if newKey != 0:
+            print("newk: "+format(newKey, '#067b'))
+
+class Debug_Cache(dict):
+    def get(self, name, default):
+        ret = dict.get(self, name, NotFound)
+        if ret is not NotFound:
+            if name in Cache.funcs:
+                print("cache found for {}: {}".format(name, self[name]))
+            return ret
+        else:
+            return default
+
+    def __setitem__(self, name, value):
+        dict.__setitem__(self, name, value)
+        if name != 'key' and name in Cache.funcs:
+            print("cache added for {}: {}".format(name, self[name]))
+
+    def validate(self, name, ret):
+        if ret != self[name] and name in Cache.funcs:
+            print("ERROR: cache ({}) != current ({}) for {}".format(self[name], ret, name))
+
 class Cache:
     cache = {}
     masterCache = {}
+    funcs = set()
+    lambdas = set()
+    debug = False
 
     @staticmethod
     def reset():
         # reinit the whole cache
         key = 0
-        Cache.masterCache = {}
-        Cache.cache = {'key': key}
+
+        if Cache.debug:
+            Cache.masterCache = Debug_MasterCache()
+            Cache.cache = Debug_Cache()
+        else:
+            Cache.masterCache = { }
+            Cache.cache = { }
+
+        Cache.cache['key'] = key
         Cache.masterCache[key] = Cache.cache
 
     @staticmethod
     def update(newKey):
         if newKey in Cache.masterCache:
-#            print("usek: "+format(newKey, '#067b'))
-#            if Cache.masterCache[newKey]['key'] != newKey:
-#                print("ERROR: key stored in cache is not the same as the new key !!!!")
-#                print("      "+format(Cache.masterCache[newKey]['key'], '#067b')+" key in cache")
             Cache.cache = Cache.masterCache[newKey]
         else:
-#            print("newk: "+format(newKey, '#067b'))
-            Cache.cache = {'key': newKey}
+            Cache.cache = Debug_Cache() if Cache.debug else { }
+            Cache.cache['key'] = newKey
             Cache.masterCache[newKey] = Cache.cache
 
     @staticmethod
     def decorator(func):
         name = func.__name__
+        Cache.funcs.add(name)
         def _decorator(self):
             ret = Cache.cache.get(name, None)
             if ret is not None:
-#                print("cache found for {}: {}".format(name, Cache.cache[func.__name__]))
-#                ret = func(self)
-#                if ret != Cache.cache[name]:
-#                    print("ERROR: cache ({}) != current ({}) for {}".format(Cache.cache[name], ret, name))
+                if Cache.debug:
+                    ret = func(self)
+                    Cache.cache.validate(name, ret)
                 return ret
             else:
                 ret = func(self)
                 Cache.cache[name] = ret
-#                print("cache added for {}: {}".format(name, Cache.cache[name]))
                 return ret
         return _decorator
 
     # for lambdas
     @staticmethod
     def ldeco(name, func):
+        Cache.lambdas.add(name)
         def _decorator(self):
             ret = Cache.cache.get(name, None)
             if ret is not None:

--- a/cache.py
+++ b/cache.py
@@ -81,9 +81,12 @@ class VersionedCache(object):
         def _decorator(arg):
             ret = self.cache.get(name, None)
             if ret is not None:
-                if self.debug and name in self.funcs:
-                    ret = func(arg)
-                    self.cache.validate(name, ret)
+                # TODO: Commented-out, because this function can get
+                # called 500K times or more during a run, and so this
+                # conditional measurably affects performance.
+                # if self.debug and name in self.funcs:
+                #     ret = func(arg)
+                #     self.cache.validate(name, ret)
                 return ret
             else:
                 ret = func(arg)

--- a/cache.py
+++ b/cache.py
@@ -48,17 +48,8 @@ class VersionedCache(object):
 
     def reset(self):
         # reinit the whole cache
-        key = 0
-
-        if self.debug:
-            self.masterCache = Debug_MasterCache()
-            self.cache = Debug_Cache()
-            self.cache['key'] = key
-        else:
-            self.masterCache = { }
-            self.cache = { }
-
-        self.masterCache[key] = self.cache
+        self.masterCache = Debug_MasterCache() if self.debug else { }
+        self.update(0)
 
     def update(self, newKey):
         cache = self.masterCache.get(newKey, None)

--- a/cache.py
+++ b/cache.py
@@ -39,7 +39,7 @@ class Debug_Cache(dict):
             print("ERROR: cache ({}) != current ({}) for {}".format(self[name], ret, name))
 
 class VersionedCache(object):
-    __slots__ = ( 'cache', 'masterCache', 'funcs', 'lambdas', 'debug' )
+    __slots__ = ( 'cache', 'masterCache', 'funcs', 'lambdas', 'debug', 'key' )
 
     def __init__(self):
         self.cache = {}
@@ -47,6 +47,7 @@ class VersionedCache(object):
         self.funcs = set()
         self.lambdas = set()
         self.debug = False
+        self.key = None
 
     def reset(self):
         # reinit the whole cache
@@ -54,13 +55,17 @@ class VersionedCache(object):
         self.update(0)
 
     def update(self, newKey):
+        if self.key == newKey and not self.debug:
+            return
         cache = self.masterCache.get(newKey, None)
         if cache is None:
             cache = Debug_Cache(key=newKey) if self.debug else { }
-            self.cache = cache
             self.masterCache[newKey] = cache
+            self.cache = cache
+            self.key = newKey
         else:
             self.cache = cache
+            self.key = newKey
 
     def decorator(self, func):
         name = func.__name__

--- a/cache.py
+++ b/cache.py
@@ -53,19 +53,18 @@ class Cache:
         if Cache.debug:
             Cache.masterCache = Debug_MasterCache()
             Cache.cache = Debug_Cache()
+            Cache.cache['key'] = key
         else:
             Cache.masterCache = { }
             Cache.cache = { }
 
-        Cache.cache['key'] = key
         Cache.masterCache[key] = Cache.cache
 
     @staticmethod
     def update(newKey):
         cache = Cache.masterCache.get(newKey, None)
         if cache is None:
-            cache = Debug_Cache() if Cache.debug else { }
-            cache['key'] = newKey
+            cache = Debug_Cache(key=newKey) if Cache.debug else { }
             Cache.cache = cache
             Cache.masterCache[newKey] = cache
         else:

--- a/cache.py
+++ b/cache.py
@@ -33,7 +33,7 @@ class Debug_Cache(dict):
             print("cache added for {}: {}".format(name, self[name]))
 
     def validate(self, name, ret):
-        if ret != self[name] and name in Cache.funcs:
+        if ret != self[name]:
             print("ERROR: cache ({}) != current ({}) for {}".format(self[name], ret, name))
 
 class Cache:
@@ -71,26 +71,22 @@ class Cache:
     def decorator(func):
         name = func.__name__
         Cache.funcs.add(name)
-        def _decorator(self):
-            ret = Cache.cache.get(name, None)
-            if ret is not None:
-                if Cache.debug:
-                    ret = func(self)
-                    Cache.cache.validate(name, ret)
-                return ret
-            else:
-                ret = func(self)
-                Cache.cache[name] = ret
-                return ret
-        return _decorator
+        return Cache._decorate(name, func)
 
     # for lambdas
     @staticmethod
     def ldeco(name, func):
         Cache.lambdas.add(name)
+        return Cache._decorate(name, func)
+
+    @staticmethod
+    def _decorate(name, func):
         def _decorator(self):
             ret = Cache.cache.get(name, None)
             if ret is not None:
+                if Cache.debug and name in Cache.funcs:
+                    ret = func(self)
+                    Cache.cache.validate(name, ret)
                 return ret
             else:
                 ret = func(self)

--- a/cache.py
+++ b/cache.py
@@ -3,14 +3,16 @@
 class NotFound: pass
 
 class Debug_MasterCache(dict):
-    def __contains__(self, newKey):
-        has_newKey = dict.__contains__(self, newKey)
-        if has_newKey:
+    def get(self, newKey, default):
+        ret = dict.get(self, newKey, NotFound)
+        if ret is not NotFound:
             print("usek: "+format(newKey, '#067b'))
             if Cache.masterCache[newKey]['key'] != newKey:
                 print("ERROR: key stored in cache is not the same as the new key !!!!")
                 print("      "+format(self[newKey]['key'], '#067b')+" key in cache")
-        return has_newKey
+            return ret
+        else:
+            return default
 
     def __setitem__(self, newKey, value):
         dict.__setitem__(self, newKey, value)
@@ -60,12 +62,14 @@ class Cache:
 
     @staticmethod
     def update(newKey):
-        if newKey in Cache.masterCache:
-            Cache.cache = Cache.masterCache[newKey]
+        cache = Cache.masterCache.get(newKey, None)
+        if cache is None:
+            cache = Debug_Cache() if Cache.debug else { }
+            cache['key'] = newKey
+            Cache.cache = cache
+            Cache.masterCache[newKey] = cache
         else:
-            Cache.cache = Debug_Cache() if Cache.debug else { }
-            Cache.cache['key'] = newKey
-            Cache.masterCache[newKey] = Cache.cache
+            Cache.cache = cache
 
     @staticmethod
     def decorator(func):

--- a/randomizer.py
+++ b/randomizer.py
@@ -13,6 +13,7 @@ from rom import RomPatcher, FakeROM
 from utils import loadRandoPreset, getDefaultMultiValues
 from version import displayedVersion
 from smbool import SMBool
+from cache import Cache
 
 import log, db
 
@@ -94,6 +95,8 @@ if __name__ == "__main__":
     parser.add_argument('--startLocationList', help="list to choose from when random",
                         dest='startLocationList', nargs='?', default=None)
     parser.add_argument('--debug', '-d', help="activate debug logging", dest='debug',
+                        action='store_true')
+    parser.add_argument('--debug-cache', help="activate debug logging for the cache", dest='debug_cache',
                         action='store_true')
     parser.add_argument('--maxDifficulty', '-t',
                         help="the maximum difficulty generated seed will be for given parameters",
@@ -260,6 +263,7 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     log.init(args.debug)
+    Cache.debug = args.debug_cache
     logger = log.get('Rando')
     # service to force an argument value and notify it
     argDict = vars(args)

--- a/smbool.py
+++ b/smbool.py
@@ -33,7 +33,7 @@ class SMBool:
 
     def __repr__(self):
         # to display the smbool as a string
-        return 'SMBool({}, {}, {}, {})'.format(self.bool, self.difficulty, self.knows, self.items)
+        return 'SMBool({}, {}, {}, {})'.format(self.bool, self.difficulty, sorted(self.knows), sorted(self.items))
 
     def __getitem__(self, index):
         # to acces the smbool as [0] for the bool and [1] for the difficulty.

--- a/solver.py
+++ b/solver.py
@@ -4,6 +4,7 @@ import sys, argparse
 from solver.interactiveSolver import InteractiveSolver
 from solver.standardSolver import StandardSolver
 from solver.conf import Conf
+from cache import Cache
 import log
 
 def interactiveSolver(args):
@@ -120,6 +121,7 @@ if __name__ == "__main__":
     parser.add_argument('--checkDuplicateMajor', dest="checkDuplicateMajor", action='store_true',
                         help="print a warning if the same major is collected more than once")
     parser.add_argument('--debug', '-d', help="activate debug logging", dest='debug', action='store_true')
+    parser.add_argument('--debug-cache', help="activate debug logging for the cache", dest='debug_cache', action='store_true')
     parser.add_argument('--firstItemsLog', '-1',
                         help="path to file where for each item type the first time it was found and where will be written (spoilers!)",
                         nargs='?', default=None, type=str, dest='firstItemsLog')
@@ -189,6 +191,7 @@ if __name__ == "__main__":
             sys.exit(-1)
 
     log.init(args.debug)
+    Cache.debug = args.debug_cache
 
     if args.interactive == True:
         interactiveSolver(args)


### PR DESCRIPTION
This cleans up the cache code:
* Debug code has been separated from the cache as much as possible
* A flag has been added to enable most cache debug output from the command line
* Cache is now a singleton instance rather than a class with static methods
* Duplicated code been refactored (which improves how it is visualized in kcachegrind)
* There may be some very small performance gains (< 1%)
