### PR TITLE
graph: add slots to AccessGraph

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -98,6 +98,10 @@ class AccessPoint(object):
         return self.ConnectedTo == self.Name
 
 class AccessGraph(object):
+    __slots__ = ( 'log', 'accessPoints', 'InterAreaTransitions',
+                  'EscapeAttributes', 'apCache', '_useCache',
+                  'availAccessPoints' )
+
     def __init__(self, accessPointList, transitions, dotFile=None):
         self.log = log.get('Graph')
         self.accessPoints = {}


### PR DESCRIPTION
This improves performance for attribute access in functions that are
called a lot (getNewAvailNodes, getPathDifficulty, and a few others).