### PR TITLE
Autoload preset when input changes

### DIFF
--- a/web/backend/presets.py
+++ b/web/backend/presets.py
@@ -398,11 +398,13 @@ class Presets(object):
             preset = self.vars.preset
 
         # check if the presets file already exists
-        password = self.vars['password']
+        password = self.vars['password'] or ""
         password = password.encode('utf-8')
         passwordSHA256 = hashlib.sha256(password).hexdigest()
         fullPath = '{}/{}.json'.format(getPresetDir(preset), preset)
         if os.path.isfile(fullPath):
+            if self.vars.action == 'load':
+                return json.dumps(PresetLoader.factory(fullPath).params)
             # load it
             end = False
             try:

--- a/web/backend/presets.py
+++ b/web/backend/presets.py
@@ -404,7 +404,13 @@ class Presets(object):
         fullPath = '{}/{}.json'.format(getPresetDir(preset), preset)
         if os.path.isfile(fullPath):
             if self.vars.action == 'load':
-                return json.dumps(PresetLoader.factory(fullPath).params)
+                self.session.presets['preset'] = self.vars.preset
+                self.session.presets['currentTab'] = self.vars.currenttab
+                skillBarData = self.getSkillLevelBarData(self.session.presets['preset'])
+                out = PresetLoader.factory(fullPath).params
+                out.pop('password', None)
+                out['skillBarData']= skillBarData
+                return json.dumps(out)
             # load it
             end = False
             try:

--- a/web/install.sh
+++ b/web/install.sh
@@ -50,6 +50,7 @@ find ~/web2py/applications/solver/static -xtype l -exec rm -f {} \;
 [ -L ~/web2py/applications/solver/static/favicon.ico ] || ln -s ~/RandomMetroidSolver/web/static/favicon.ico ~/web2py/applications/solver/static/favicon.ico
 [ -L ~/web2py/applications/solver/static/favicon.png ] || ln -s ~/RandomMetroidSolver/web/static/favicon.png ~/web2py/applications/solver/static/favicon.png
 
+[ -L ~/web2py/applications/solver/static/preset.js ] || ln -s ~/RandomMetroidSolver/web/static/preset.js ~/web2py/applications/solver/static/preset.js
 [ -L ~/web2py/applications/solver/static/css/bootstrap-tour.min.css ] || ln -s ~/RandomMetroidSolver/web/static/bootstrap-tour.min.css ~/web2py/applications/solver/static/css/bootstrap-tour.min.css
 [ -L ~/web2py/applications/solver/static/barrating ] || ln -s ~/RandomMetroidSolver/web/static/barrating ~/web2py/applications/solver/static/barrating
 [ -L ~/web2py/applications/solver/static/js/bootstrap-tour.min.js ] || ln -s ~/RandomMetroidSolver/web/static/bootstrap-tour.min.js ~/web2py/applications/solver/static/js/bootstrap-tour.min.js

--- a/web/static/preset.js
+++ b/web/static/preset.js
@@ -9,6 +9,7 @@ const difficulty_by_level = {
 }
 
 function loadPresetOk(data) {
+    $('#presetActionBox').removeClass('preset-loading');
     Object.entries(data.Settings).forEach(([key, value]) => {
         document.getElementById(key).value = value;
     })
@@ -95,6 +96,7 @@ function verifyPreset(data_in) {
 }
 
 function loadPreset() {
+    $('#presetActionBox').addClass('preset-loading');
     var dataDict = {
         preset: document.getElementById("preset").value,
         action: "load",

--- a/web/static/preset.js
+++ b/web/static/preset.js
@@ -96,6 +96,7 @@ function verifyPreset(data_in) {
 }
 
 function loadPreset() {
+    $('#flash').hide();
     $('#presetActionBox').addClass('preset-loading');
     var dataDict = {
         preset: document.getElementById("preset").value,
@@ -111,7 +112,11 @@ function loadPreset() {
     });
 
     request.done(loadPresetOk);
-    request.fail((e) => console.error(e));
+    request.fail((e) => {
+        const flash = $("#flash");
+        flash.text("An error occurred while loading preset. Please refresh the page and try again.");
+        flash.show();
+    })
 }
 
 function loadSkillBar(skillBarData) {

--- a/web/static/preset.js
+++ b/web/static/preset.js
@@ -13,19 +13,11 @@ function loadPresetOk(data) {
         document.getElementById(key).value = value;
     })
 
-    const levels = [];
-    const is_checked = {};
-    const not_checked = {};
     Object.entries(data.Knows).forEach(([key, value]) => {
         const [checked, level] = value;
         const checkbox = document.getElementById(key + "_bool");
         if (checkbox.disabled) {
             return;
-        }
-        if (!checked) {
-            is_checked[level] = true;
-        } else {
-            not_checked[level] = true;
         }
         checkbox.value = checked ? 'on' : 'off';
         checkbox.checked = checked;
@@ -36,17 +28,18 @@ function loadPresetOk(data) {
         const selector = `#${key}_diff + .br-widget [data-rating-value="${difficulty}"]`;
         const bar = document.querySelector(selector);
         bar.click();
+    })
 
-        Object.entries(data.Controller).forEach(([key, value]) => {
-            if (key === "Moonwalk") {
-                document.getElementById("Moonwalk").checked = value === "on";
-                return;
-            }
-            const select = document.getElementById(key);
-            select.value = value;
-            select.dispatchEvent(new Event('change'));
-        })
-
+    Object.entries(data.Controller).forEach(([key, value]) => {
+        if (key === "Moonwalk") {
+            const checkbox = document.getElementById("Moonwalk");
+            checkbox.checked = value;
+            checkbox.value = value ? 'on' : 'off';
+            return;
+        }
+        const select = document.getElementById(key);
+        select.value = value;
+        select.dispatchEvent(new Event('change'));
     })
 
     loadSkillBar(data.skillBarData);
@@ -123,7 +116,7 @@ function loadSkillBar(skillBarData) {
     const id_texts = [
         ['skill-bar__title', skillBarData.custom[0]],
         ['skill-bar__score', skillBarData.custom[1]],
-        ['skill-bar__knowns-known', skillBarData.knownsKnown],
+        ['skill-bar__knows-known', skillBarData.knowsKnown],
         ['skill-bar__last-action', skillBarData.lastAction],
     ];
     id_texts.forEach(([id, text]) => {

--- a/web/static/preset.js
+++ b/web/static/preset.js
@@ -1,199 +1,199 @@
 const difficulty_by_level = {
-  1: 'easy',
-  5: 'medium',
-  10: 'hard',
-  25: 'very hard',
-  50: 'hardcore',
-  100: 'mania',
-  0: 'mania', // unchecked defaults to mania
+    1: 'easy',
+    5: 'medium',
+    10: 'hard',
+    25: 'very hard',
+    50: 'hardcore',
+    100: 'mania',
+    0: 'mania', // unchecked defaults to mania
 }
 
 function loadPresetOk(data) {
-  Object.entries(data.Settings).forEach(([key, value]) => {
-    document.getElementById(key).value = value
-  })
-
-  const levels = []
-  const is_checked = {}
-  const not_checked = {}
-  Object.entries(data.Knows).forEach(([key, value]) => {
-    const [checked, level] = value
-    const checkbox = document.getElementById(key + "_bool")
-    if (checkbox.disabled) {
-      return
-    }
-    if (!checked) {
-      is_checked[level] = true
-    } else {
-      not_checked[level] = true
-    }
-    checkbox.value = checked ? 'on' : 'off'
-    checkbox.checked = checked
-    checkbox.dispatchEvent(new Event('change'));
-    checkbox.dispatchEvent(new Event('click'));
-
-    const difficulty = difficulty_by_level[level]
-    const selector = `#${key}_diff + .br-widget [data-rating-value="${difficulty}"]`
-    const bar = document.querySelector(selector)
-    bar.click()
-
-    Object.entries(data.Controller).forEach(([key, value]) => {
-      if (key === "Moonwalk") {
-        document.getElementById("Moonwalk").checked = value === "on"
-        return
-      }
-      const select = document.getElementById(key)
-      select.value = value
-      select.dispatchEvent(new Event('change'));
+    Object.entries(data.Settings).forEach(([key, value]) => {
+        document.getElementById(key).value = value;
     })
 
-  })
+    const levels = [];
+    const is_checked = {};
+    const not_checked = {};
+    Object.entries(data.Knows).forEach(([key, value]) => {
+        const [checked, level] = value;
+        const checkbox = document.getElementById(key + "_bool");
+        if (checkbox.disabled) {
+            return;
+        }
+        if (!checked) {
+            is_checked[level] = true;
+        } else {
+            not_checked[level] = true;
+        }
+        checkbox.value = checked ? 'on' : 'off';
+        checkbox.checked = checked;
+        checkbox.dispatchEvent(new Event('change'));
+        checkbox.dispatchEvent(new Event('click'));
 
-  loadSkillBar(data.skillBarData);
-  drawSkillChart(data.skillBarData);
-  verifyPreset(data)
+        const difficulty = difficulty_by_level[level];
+        const selector = `#${key}_diff + .br-widget [data-rating-value="${difficulty}"]`;
+        const bar = document.querySelector(selector);
+        bar.click();
+
+        Object.entries(data.Controller).forEach(([key, value]) => {
+            if (key === "Moonwalk") {
+                document.getElementById("Moonwalk").checked = value === "on";
+                return;
+            }
+            const select = document.getElementById(key);
+            select.value = value;
+            select.dispatchEvent(new Event('change'));
+        })
+
+    })
+
+    loadSkillBar(data.skillBarData);
+    drawSkillChart(data.skillBarData);
+    verifyPreset(data);
 }
 
 function verifyPreset(data_in) {
-  const compare = (category, key, value1, value2) => {
-    if (value1 !== value2) {
-      const text1 = JSON.stringify(value1);
-      const text2 = JSON.stringify(value2);
-      console.warn(`Mismatch for data.Knows.${key} ${text1} !== ${text2}`);
+    const compare = (category, key, value1, value2) => {
+        if (value1 !== value2) {
+            const text1 = JSON.stringify(value1);
+            const text2 = JSON.stringify(value2);
+            console.warn(`Mismatch for data.Knows.${key} ${text1} !== ${text2}`);
+        }
     }
-  }
-  const data_out = window.getPresetDataDict();
+    const data_out = window.getPresetDataDict();
 
-  Object.entries(data_in.Settings).forEach(([key, value]) => {
-    const value_in = data_in.Settings[key]
-    const value_out = data_out[key]
-    compare('Settings', key, value_in, value_out)
-  });
+    Object.entries(data_in.Settings).forEach(([key, value]) => {
+        const value_in = data_in.Settings[key];
+        const value_out = data_out[key];
+        compare('Settings', key, value_in, value_out);
+    });
 
-  // these are skipped because they are disabled on front end
-  const skip_knows = ['WallJump', 'ShineSpark', 'MidAirMorph', 'CrouchJump']
+    // these are skipped because they are disabled on front end
+    const skip_knows = ['WallJump', 'ShineSpark', 'MidAirMorph', 'CrouchJump'];
 
-  Object.entries(data_in.Knows).forEach(([key, value]) => {
-    if (skip_knows.includes(key)) {
-      return
-    }
-    if (data_in.Knows[key][0]) {
-      const bool_in = data_in.Knows[key][0] ? "on" : "off"
-      const bool_out = data_out[key + '_bool']
-      compare('Knows', key + '_bool', bool_in, bool_out)
+    Object.entries(data_in.Knows).forEach(([key, value]) => {
+        if (skip_knows.includes(key)) {
+            return;
+        }
+        if (data_in.Knows[key][0]) {
+            const bool_in = data_in.Knows[key][0] ? "on" : "off";
+            const bool_out = data_out[key + '_bool'];
+            compare('Knows', key + '_bool', bool_in, bool_out);
 
-      const diff_in = difficulty_by_level[data_in.Knows[key][1]]
-      const diff_out = data_out[key + '_diff']
-      compare('Knows', key + '_diff', diff_in, diff_out)
-    } else {
-      compare('Knows', key + '_bool', undefined, data_out[key + '_bool'])
-      compare('Knows', key + '_diff', undefined, data_out[key + '_diff'])
-    }
-  });
+            const diff_in = difficulty_by_level[data_in.Knows[key][1]];
+            const diff_out = data_out[key + '_diff'];
+            compare('Knows', key + '_diff', diff_in, diff_out);
+        } else {
+            compare('Knows', key + '_bool', undefined, data_out[key + '_bool']);
+            compare('Knows', key + '_diff', undefined, data_out[key + '_diff']);
+        }
+    });
 
-  Object.entries(data_in.Controller).forEach(([key, value]) => {
-    let value_in = data_in.Controller[key]
-    const value_out = data_out[key]
-    if (key === "Moonwalk") {
-      value_in = value_in ? 'on' : 'off'
-    }
-    compare('Controller', key, value_in, value_out)
-  });
+    Object.entries(data_in.Controller).forEach(([key, value]) => {
+        let value_in = data_in.Controller[key];
+        const value_out = data_out[key];
+        if (key === "Moonwalk") {
+            value_in = value_in ? 'on' : 'off';
+        }
+        compare('Controller', key, value_in, value_out);
+    });
 }
 
 function loadPreset() {
-  var dataDict = {
-    preset: document.getElementById("preset").value,
-    action: "load",
-    currenttab: document.getElementById("currenttab").value,
-  };
+    var dataDict = {
+        preset: document.getElementById("preset").value,
+        action: "load",
+        currenttab: document.getElementById("currenttab").value,
+    };
 
-  // call web service to update the session with the params from the rando preset and update the parameters in the page
-  var request = $.ajax({
-      url: "/skillPresetActionWebService",
-      data: dataDict,
-      dataType: "json"
-  });
+    // call web service to update the session with the params from the rando preset and update the parameters in the page
+    var request = $.ajax({
+            url: "/skillPresetActionWebService",
+            data: dataDict,
+            dataType: "json"
+    });
 
-  request.done(loadPresetOk)
-  request.fail((e) => console.error(e));
+    request.done(loadPresetOk);
+    request.fail((e) => console.error(e));
 }
 
 function loadSkillBar(skillBarData) {
-  const id_texts = [
-    ['skill-bar__title', skillBarData.custom[0]],
-    ['skill-bar__score', skillBarData.custom[1]],
-    ['skill-bar__knowns-known', skillBarData.knownsKnown],
-    ['skill-bar__last-action', skillBarData.lastAction],
-  ]
-  id_texts.forEach(([id, text]) => {
-    $("#"+id).text(text)
-  })
+    const id_texts = [
+        ['skill-bar__title', skillBarData.custom[0]],
+        ['skill-bar__score', skillBarData.custom[1]],
+        ['skill-bar__knowns-known', skillBarData.knownsKnown],
+        ['skill-bar__last-action', skillBarData.lastAction],
+    ];
+    id_texts.forEach(([id, text]) => {
+        $("#"+id).text(text);
+    })
 }
 
 
 function drawSkillChart(skillBarData) {
-  const rows = []
+    const rows = [];
 
-  const mult = 2
-  const score = 100 + skillBarData["custom"][1] * mult
-  const lower = 100 + skillBarData["standards"]["newbie"] * mult
-  const upper = 100 + skillBarData["standards"]["samus"] * mult
+    const mult = 2;
+    const score = 100 + skillBarData["custom"][1] * mult;
+    const lower = 100 + skillBarData["standards"]["newbie"] * mult;
+    const upper = 100 + skillBarData["standards"]["samus"] * mult;
 
-  let previousStdScore = lower
-  let previousPreset = 'newbie'
-  let stop = false
-  const presets = ['casual', 'regular', 'veteran', 'expert', 'master', 'samus']
-  presets.forEach((preset) => {
-    if (stop) {
-      return
-    }
-    const stdScore = 100 + skillBarData["standards"][preset] * mult
-    if (stdScore <= score) {
-      rows.push([ 'Skill', previousPreset, new Date(previousStdScore), new Date(stdScore)])
-    } else {
-      rows.push([ 'Skill', previousPreset, new Date(previousStdScore), new Date(score)])
-      stop = true
-    }
-    previousStdScore = stdScore
-    previousPreset = preset
-  })
+    let previousStdScore = lower;
+    let previousPreset = 'newbie';
+    let stop = false;
+    const presets = ['casual', 'regular', 'veteran', 'expert', 'master', 'samus'];
+    presets.forEach((preset) => {
+        if (stop) {
+            return;
+        }
+        const stdScore = 100 + skillBarData["standards"][preset] * mult;
+        if (stdScore <= score) {
+            rows.push([ 'Skill', previousPreset, new Date(previousStdScore), new Date(stdScore)]);
+        } else {
+            rows.push([ 'Skill', previousPreset, new Date(previousStdScore), new Date(score)]);
+            stop = true;
+        }
+        previousStdScore = stdScore;
+        previousPreset = preset;
+    })
 
-  var container = document.getElementById('timeline');
-  container.innerHTML = ""
-  var chart = new google.visualization.Timeline(container);
-  var dataTable = new google.visualization.DataTable();
+    var container = document.getElementById('timeline');
+    container.innerHTML = "";
+    var chart = new google.visualization.Timeline(container);
+    var dataTable = new google.visualization.DataTable();
 
-  dataTable.addColumn({ type: 'string', id: 'Role' });
-  dataTable.addColumn({ type: 'string', id: 'Difficulty' });
-  dataTable.addColumn({ type: 'date', id: 'Start' });
-  dataTable.addColumn({ type: 'date', id: 'End' });
-  dataTable.addRows(rows)
+    dataTable.addColumn({ type: 'string', id: 'Role' });
+    dataTable.addColumn({ type: 'string', id: 'Difficulty' });
+    dataTable.addColumn({ type: 'date', id: 'Start' });
+    dataTable.addColumn({ type: 'date', id: 'End' });
+    dataTable.addRows(rows);
 
-  var options = {
-    hAxis: {
-      minValue: new Date(lower),
-      maxValue: new Date(upper),
-    },
-    timeline: { groupByRowLabel: true},
-    tooltip: { trigger: 'none' },
-    colors: ['#6daa53', '#C1B725', '#e69235', '#d13434', '#123456', '#000000'],
-    avoidOverlappingGridLines: false
-  };
+    var options = {
+        hAxis: {
+            minValue: new Date(lower),
+            maxValue: new Date(upper),
+        },
+        timeline: { groupByRowLabel: true},
+        tooltip: { trigger: 'none' },
+        colors: ['#6daa53', '#C1B725', '#e69235', '#d13434', '#123456', '#000000'],
+        avoidOverlappingGridLines: false
+    };
 
-  window.google.visualization.events.addListener(chart, 'ready', function () {
-    // remove haxis label
-    var labels = container.getElementsByTagName('text');
+    window.google.visualization.events.addListener(chart, 'ready', function () {
+        // remove haxis label
+        var labels = container.getElementsByTagName('text');
 
-    for (let i = 0; i < labels.length; i++) {
-      if (labels[i].textContent.substring(0,1) == '0' || labels[i].textContent.substring(0,1) == '1') {
-        labels[i].parentNode.removeChild(labels[i]);
-        i--;
-      }
-    }
+        for (let i = 0; i < labels.length; i++) {
+            if (labels[i].textContent.substring(0,1) == '0' || labels[i].textContent.substring(0,1) == '1') {
+                labels[i].parentNode.removeChild(labels[i]);
+                i--;
+            }
+        }
 
-  });
-  chart.draw(dataTable, options);
+    });
+    chart.draw(dataTable, options);
 }
 
 

--- a/web/static/preset.js
+++ b/web/static/preset.js
@@ -1,0 +1,115 @@
+const difficulty_by_level = {
+  1: 'easy',
+  5: 'medium',
+  10: 'hard',
+  25: 'very hard',
+  50: 'hardcore',
+  100: 'mania',
+  0: 'mania', // unchecked defaults to mania
+}
+
+function loadPresetOk(data) {
+  Object.entries(data.Settings).forEach(([key, value]) => {
+    document.getElementById(key).value = value
+  })
+
+  const levels = []
+  const is_checked = {}
+  const not_checked = {}
+  Object.entries(data.Knows).forEach(([key, value]) => {
+    const [checked, level] = value
+    const checkbox = document.getElementById(key + "_bool")
+    if (checkbox.disabled) {
+      return
+    }
+    if (!checked) {
+      is_checked[level] = true
+    } else {
+      not_checked[level] = true
+    }
+    checkbox.checked = checked
+    checkbox.dispatchEvent(new Event('change'));
+
+    const difficulty = difficulty_by_level[level]
+    const selector = `#${key}_diff + .br-widget [data-rating-value="${difficulty}"]`
+    const bar = document.querySelector(selector)
+    bar.click()
+
+    Object.entries(data.Controller).forEach(([key, value]) => {
+      if (key === "Moonwalk") {
+        document.getElementById("Moonwalk").checked = value === "on"
+        return
+      }
+      const select = document.getElementById(key)
+      select.value = value
+      select.dispatchEvent(new Event('change'));
+    })
+
+  })
+  verifyPreset(data)
+}
+
+function verifyPreset(data_in) {
+  const compare = (category, key, value1, value2) => {
+    if (value1 !== value2) {
+      const text1 = JSON.stringify(value1);
+      const text2 = JSON.stringify(value2);
+      console.warn(`Mismatch for data.Knows.${key} ${text1} !== ${text2}`);
+    }
+  }
+  const data_out = window.getPresetDataDict();
+
+  Object.entries(data_in.Settings).forEach(([key, value]) => {
+    const value_in = data_in.Settings[key]
+    const value_out = data_out[key]
+    compare('Settings', key, value_in, value_out)
+  });
+
+  // these are skipped because they are disabled on front end
+  const skip_knows = ['WallJump', 'ShineSpark', 'MidAirMorph', 'CrouchJump']
+
+  Object.entries(data_in.Knows).forEach(([key, value]) => {
+    if (skip_knows.includes(key)) {
+      return
+    }
+    if (data_in.Knows[key][0]) {
+      const bool_in = data_in.Knows[key][0] ? "on" : "off"
+      const bool_out = data_out[key + '_bool']
+      compare('Knows', key + '_bool', bool_in, bool_out)
+
+      const diff_in = difficulty_by_level[data_in.Knows[key][1]]
+      const diff_out = data_out[key + '_diff']
+      compare('Knows', key + '_diff', diff_in, diff_out)
+    } else {
+      compare('Knows', key + '_bool', undefined, data_out[key + '_bool'])
+      compare('Knows', key + '_diff', undefined, data_out[key + '_diff'])
+    }
+  });
+
+  Object.entries(data_in.Controller).forEach(([key, value]) => {
+    let value_in = data_in.Controller[key]
+    const value_out = data_out[key]
+    if (key === "Moonwalk") {
+      value_in = value_in ? 'on' : 'off'
+    }
+    compare('Controller', key, value_in, value_out)
+  });
+}
+
+function loadPreset() {
+  var dataDict = {
+    preset: document.getElementById("preset").value,
+    action: "load",
+    currenttab: document.getElementById("currenttab").value,
+  };
+
+  // call web service to update the session with the params from the rando preset and update the parameters in the page
+  var request = $.ajax({
+      url: "/skillPresetActionWebService",
+      data: dataDict,
+      dataType: "json"
+  });
+
+  request.done(loadPresetOk)
+  request.fail((e) => console.error(e));
+}

--- a/web/views/presets.html
+++ b/web/views/presets.html
@@ -663,9 +663,7 @@ pass
         </tr>
         <tr>
           <td></td>
-          <td>
-            <input class="full" name="action" type="submit" value="Load"/>
-          </td>
+          <td></td>
           <td>
             <input class="full btn btn-default" onclick="askPassword('Update');" value="Update"/>
           </td>
@@ -683,20 +681,20 @@ pass
       <table class="full">
         <tr>
           <td>
-            <h3 class="center">{{=skillBarData["custom"][0]}}</h3>
+            <h3 id="skill-bar__title" class="center">{{=skillBarData["custom"][0]}}</h3>
           </td>
         </tr>
       </table>
       <table class="full">
         <tr>
           <td>Techniques known:</td>
-          <td>{{=skillBarData["knowsKnown"]}}</td>
+          <td id="skill-bar__knowns-known">{{=skillBarData["knowsKnown"]}}</td>
           <td>Skill score:</td>
-          <td>{{=skillBarData["custom"][1]}}</td>
+          <td id="skill-bar__score">{{=skillBarData["custom"][1]}}</td>
         </tr>
         <tr>
           <td>Last updated:</td>
-          <td>{{=skillBarData["lastAction"]}}</td>
+          <td id="skill-bar__last-action">{{=skillBarData["lastAction"]}}</td>
           <td></td>
           <td></td>
         </tr>

--- a/web/views/presets.html
+++ b/web/views/presets.html
@@ -688,7 +688,7 @@ pass
       <table class="full">
         <tr>
           <td>Techniques known:</td>
-          <td id="skill-bar__knowns-known">{{=skillBarData["knowsKnown"]}}</td>
+          <td id="skill-bar__knows-known">{{=skillBarData["knowsKnown"]}}</td>
           <td>Skill score:</td>
           <td id="skill-bar__score">{{=skillBarData["custom"][1]}}</td>
         </tr>

--- a/web/views/presets.html
+++ b/web/views/presets.html
@@ -17,6 +17,7 @@ extend 'layout.html'
 <script src="{{=URL('static','barrating/jquery.barrating.min.js')}}"></script>
 
 <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script type="text/javascript" src="{{=URL('static','preset.js')}}"></script>
 
 <style>
 {{include 'solver_web/varia.css'}}
@@ -290,10 +291,7 @@ function setGauntletEnergy(gauntletSetting, bombItem) {
   }
 }
 
-function ajaxPresetActionCall(action) {
-    // store the action to retreive it after the ajax call is completed
-    document.getElementById("stored_action").value = action;
-
+function getPresetDataDict(action) {
     var dataDict = {
         action: action,
         currenttab: document.getElementById("currenttab").value,
@@ -335,6 +333,15 @@ function ajaxPresetActionCall(action) {
     } else {
         dataDict["Moonwalk"] = "off";
     }
+
+    return dataDict
+}
+
+function ajaxPresetActionCall(action) {
+    // store the action to retreive it after the ajax call is completed
+    document.getElementById("stored_action").value = action;
+
+    var dataDict = getPresetDataDict(action);
 
     // call web service with parameters
     var request = $.ajax({
@@ -646,7 +653,7 @@ pass
         <colgroup><col class="quarter" /><col class="quarter" /><col class="quarter" /><col class="quarter"></colgroup>
         <tr>
           <td>Preset:</td>
-          <td colspan="3">{{=SELECT(OPTGROUP(*stdPresets, **dict(_label="Standard presets")), OPTGROUP(*tourPresets, **dict(_label="Tournament presets")), OPTGROUP(*comPresets, **dict(_label="Community presets")), **dict(_name="preset", _id="preset", value=session.presets["preset"], _class="chzn-select"))}}</td>
+          <td colspan="3">{{=SELECT(OPTGROUP(*stdPresets, **dict(_label="Standard presets")), OPTGROUP(*tourPresets, **dict(_label="Tournament presets")), OPTGROUP(*comPresets, **dict(_label="Community presets")), **dict(_name="preset", _id="preset", value=session.presets["preset"], _class="chzn-select", _onChange="loadPreset()"))}}</td>
           <td id="presetStep"><button type="button" onclick="startTheTour(0)">?</button></td>
         </tr>
         <tr>

--- a/web/views/presets.html
+++ b/web/views/presets.html
@@ -21,6 +21,17 @@ extend 'layout.html'
 
 <style>
 {{include 'solver_web/varia.css'}}
+.preset-loading {
+  position: relative;
+}
+.preset-loading:before {
+  background: rgba(255, 255, 255, 0.5);
+  content: "";
+  display: block;
+  inset: 0;
+  position:absolute;
+  z-index: 1;
+}
 .column {
     padding-right: 10px;
 }
@@ -648,7 +659,7 @@ pass
 <div class="main">
 <form id="presetForm" class="presetform" method="post">
   <div class="row">
-    <div class="columnThird">
+    <div class="columnThird" id="presetActionBox">
       <table class="full">
         <colgroup><col class="quarter" /><col class="quarter" /><col class="quarter" /><col class="quarter"></colgroup>
         <tr>

--- a/web/views/presets.html
+++ b/web/views/presets.html
@@ -392,7 +392,7 @@ function startTheTour(step=-1) {
     {
       element: "#presetStep",
       title: "Preset",
-      content: "The standard presets are base presets to create yours upon.<br/>Select one of the standard presets (sorted in increased difficulty), or you own from community presets, then click on the Load button.<br/>Check out what are the tricks required for popular tournaments by loading a tournament preset.<br/><br/><b>Standard presets outlook:</b><br/><ul><li><b>newbie: </b>New to randomizers, but completed Super Metroid 100% and knows basic techniques (Wall Jump, Shinespark, Mid-air Morph)</li><li><b>casual:</b> occasional rando player. No hell runs or suitless Maridia, some easy to learn tricks in logic.</li><li><b>regular: </b>plays rando regularly. Knows tricks that are not too hard and open up the game: hell runs (generous energy requirements), suitless Maridia, lava dive, gate glitches, Alcatraz, Gauntlet...</li><li><b>veteran:</b> experienced rando player. Harder everything, some tougher tricks in logic.</li><li><b>expert: </b>knows almost all tricks: full suitless Maridia, Lower Norfair hell runs, hi-jumpless Lava Dive (mania difficulty only, so not by default in most rando settings)</li><li><b>master:</b> Everything on hardest, all tricks known.</li></ul>"
+      content: "The standard presets are base presets to create yours upon.<br/>Select one of the standard presets (sorted in increased difficulty), or you own from community presets.<br/>Check out what are the tricks required for popular tournaments by loading a tournament preset.<br/><br/><b>Standard presets outlook:</b><br/><ul><li><b>newbie: </b>New to randomizers, but completed Super Metroid 100% and knows basic techniques (Wall Jump, Shinespark, Mid-air Morph)</li><li><b>casual:</b> occasional rando player. No hell runs or suitless Maridia, some easy to learn tricks in logic.</li><li><b>regular: </b>plays rando regularly. Knows tricks that are not too hard and open up the game: hell runs (generous energy requirements), suitless Maridia, lava dive, gate glitches, Alcatraz, Gauntlet...</li><li><b>veteran:</b> experienced rando player. Harder everything, some tougher tricks in logic.</li><li><b>expert: </b>knows almost all tricks: full suitless Maridia, Lower Norfair hell runs, hi-jumpless Lava Dive (mania difficulty only, so not by default in most rando settings)</li><li><b>master:</b> Everything on hardest, all tricks known.</li></ul>"
     },
     {
       element: "#presetCreateStep",
@@ -402,7 +402,7 @@ function startTheTour(step=-1) {
     {
       element: "#buttonsStep",
       title: "Actions",
-      content: "<ul><li><b>Load</b>: Load your preset or one of the predefined ones</li><li><b>Update</b>: Update your preset after you've mastered a new technique</li><li><b>Create</b>: create your own preset based on the currently loaded one.</li></ul>"
+      content: "<ul><li><b>Update</b>: Update your preset after you've mastered a new technique</li><li><b>Create</b>: create your own preset based on the currently loaded one.</li></ul>"
     },
     {
       element: "#xrayStep",


### PR DESCRIPTION
This updates the preset page to autoload the preset. If you change the preset dropdown the center and right columns on the top should update, as well as all the information in every tab.

### Notes

* I made a new presets.js file. Dude that we wanted to start organizing the JS, but I can merge this into presets.html if preferred.
* There's a `verifyPreset` function that runs after everything is done. This verifies that the data from the ajax call matches the data on the page (using the `getPresetDataDict` function also used when the user submits the form). I wrote this because validating that every setting was updated is tedious. Should we remove this?
* I wasn't sure how likely errors were, so I put a basic message telling people to reload the page.