### PR TITLE
Number of objectives

### DIFF
--- a/randomizer.py
+++ b/randomizer.py
@@ -465,19 +465,17 @@ if __name__ == "__main__":
             addedObjectives = 1
 
         if args.objective:
-            maxActiveGoals = Objectives.maxActiveGoals - addedObjectives
             try:
                 nbObjectives = int(args.objective[0])
             except:
                 nbObjectives = 0 if "random" in args.objective else None
             if nbObjectives is not None:
                 availableObjectives = args.objectiveList.split(',') if args.objectiveList is not None else objectives
-                if nbObjectives > 0:
-                    nbObjectives = min(nbObjectives, maxActiveGoals, len(availableObjectives))
-                else:
-                    nbObjectives = random.randint(1, min(maxActiveGoals, len(availableObjectives)))
+                if nbObjectives == 0:
+                    nbObjectives = random.randint(1, min(Objectives.maxActiveGoals, len(availableObjectives)))
                 objectivesManager.setRandom(nbObjectives, availableObjectives)
             else:
+                maxActiveGoals = Objectives.maxActiveGoals - addedObjectives
                 if len(args.objective) > maxActiveGoals:
                     args.objective = args.objective[0:maxActiveGoals]
                 for goal in args.objective:

--- a/utils/db.py
+++ b/utils/db.py
@@ -391,7 +391,7 @@ order by r.id;"""
 
         # custom sort of the params
         paramsHead = []
-        for param in ['seed', 'preset', 'startLocation', 'startLocationMultiSelect', 'areaRandomization', 'areaLayout', 'lightAreaRandomization', 'doorsColorsRando', 'allowGreyDoors', 'bossRandomization', 'minimizer', 'minimizerQty', 'majorsSplit', 'majorsSplitMultiSelect', 'scavNumLocs', 'scavRandomized', 'progressionSpeed', 'progressionSpeedMultiSelect', 'maxDifficulty', 'morphPlacement', 'morphPlacementMultiSelect', 'suitsRestriction', 'energyQty', 'energyQtyMultiSelect', 'minorQty', 'missileQty', 'superQty', 'powerBombQty', 'progressionDifficulty', 'progressionDifficultyMultiSelect', 'escapeRando', 'removeEscapeEnemies', 'objective', 'objectiveMultiSelect', 'nbObjective', 'tourian', 'tourianMultiSelect', 'funCombat', 'funMovement', 'funSuits', 'hideItems', 'strictMinors']:
+        for param in ['seed', 'preset', 'startLocation', 'startLocationMultiSelect', 'areaRandomization', 'areaLayout', 'lightAreaRandomization', 'doorsColorsRando', 'allowGreyDoors', 'bossRandomization', 'minimizer', 'minimizerQty', 'majorsSplit', 'majorsSplitMultiSelect', 'scavNumLocs', 'scavRandomized', 'progressionSpeed', 'progressionSpeedMultiSelect', 'maxDifficulty', 'morphPlacement', 'morphPlacementMultiSelect', 'suitsRestriction', 'energyQty', 'energyQtyMultiSelect', 'minorQty', 'missileQty', 'superQty', 'powerBombQty', 'progressionDifficulty', 'progressionDifficultyMultiSelect', 'escapeRando', 'removeEscapeEnemies', 'objective', 'objectiveMultiSelect', 'tourian', 'tourianMultiSelect', 'funCombat', 'funMovement', 'funSuits', 'hideItems', 'strictMinors']:
             if param in paramsSet:
                 paramsHead.append(param)
                 paramsSet.remove(param)
@@ -418,7 +418,7 @@ order by 1,2;"""
         #     (param1, count1, count2, 0, ...)
         #     (param2, 0, 0, count3, ...)]
         groups = {
-            'Randomizer parameters': ['preset', 'startLocation', 'majorsSplit', 'scavNumLocs', 'scavRandomized', 'progressionSpeed', 'maxDifficulty', 'morphPlacement', 'progressionDifficulty', 'suitsRestriction', 'hideItems', 'objective', 'nbObjective', 'tourian'],
+            'Randomizer parameters': ['preset', 'startLocation', 'majorsSplit', 'scavNumLocs', 'scavRandomized', 'progressionSpeed', 'maxDifficulty', 'morphPlacement', 'progressionDifficulty', 'suitsRestriction', 'hideItems', 'objective', 'tourian'],
             'Ammo and Energy': ['minorQty', 'energyQty', 'strictMinors', 'missileQty', 'superQty', 'powerBombQty'],
             'Areas and Fun': ['areaRandomization', 'lightAreaRandomization', 'areaLayout', 'doorsColorsRando', 'allowGreyDoors', 'bossRandomization', 'minimizer', 'minimizerQty', 'escapeRando', 'removeEscapeEnemies', 'funCombat', 'funMovement', 'funSuits'],
             'Patches': ['layoutPatches', 'variaTweaks', 'nerfedCharge', 'gravityBehaviour', 'itemsounds', 'elevators_speed', 'fast_doors', 'spinjumprestart', 'rando_speed', 'Infinite_Space_Jump', 'refill_before_save', 'hud', 'animals', 'No_Music', 'random_music', 'relaxed_round_robin_cf']

--- a/utils/db.py
+++ b/utils/db.py
@@ -391,7 +391,7 @@ order by r.id;"""
 
         # custom sort of the params
         paramsHead = []
-        for param in ['seed', 'preset', 'startLocation', 'startLocationMultiSelect', 'areaRandomization', 'areaLayout', 'lightAreaRandomization', 'doorsColorsRando', 'allowGreyDoors', 'bossRandomization', 'minimizer', 'minimizerQty', 'majorsSplit', 'majorsSplitMultiSelect', 'scavNumLocs', 'scavRandomized', 'progressionSpeed', 'progressionSpeedMultiSelect', 'maxDifficulty', 'morphPlacement', 'morphPlacementMultiSelect', 'suitsRestriction', 'energyQty', 'energyQtyMultiSelect', 'minorQty', 'missileQty', 'superQty', 'powerBombQty', 'progressionDifficulty', 'progressionDifficultyMultiSelect', 'escapeRando', 'removeEscapeEnemies', 'objective', 'objectiveMultiSelect', 'tourian', 'tourianMultiSelect', 'funCombat', 'funMovement', 'funSuits', 'hideItems', 'strictMinors']:
+        for param in ['seed', 'preset', 'startLocation', 'startLocationMultiSelect', 'areaRandomization', 'areaLayout', 'lightAreaRandomization', 'doorsColorsRando', 'allowGreyDoors', 'bossRandomization', 'minimizer', 'minimizerQty', 'majorsSplit', 'majorsSplitMultiSelect', 'scavNumLocs', 'scavRandomized', 'progressionSpeed', 'progressionSpeedMultiSelect', 'maxDifficulty', 'morphPlacement', 'morphPlacementMultiSelect', 'suitsRestriction', 'energyQty', 'energyQtyMultiSelect', 'minorQty', 'missileQty', 'superQty', 'powerBombQty', 'progressionDifficulty', 'progressionDifficultyMultiSelect', 'escapeRando', 'removeEscapeEnemies', 'objective', 'objectiveMultiSelect', 'nbObjective', 'tourian', 'tourianMultiSelect', 'funCombat', 'funMovement', 'funSuits', 'hideItems', 'strictMinors']:
             if param in paramsSet:
                 paramsHead.append(param)
                 paramsSet.remove(param)
@@ -418,7 +418,7 @@ order by 1,2;"""
         #     (param1, count1, count2, 0, ...)
         #     (param2, 0, 0, count3, ...)]
         groups = {
-            'Randomizer parameters': ['preset', 'startLocation', 'majorsSplit', 'scavNumLocs', 'scavRandomized', 'progressionSpeed', 'maxDifficulty', 'morphPlacement', 'progressionDifficulty', 'suitsRestriction', 'hideItems', 'objective', 'tourian'],
+            'Randomizer parameters': ['preset', 'startLocation', 'majorsSplit', 'scavNumLocs', 'scavRandomized', 'progressionSpeed', 'maxDifficulty', 'morphPlacement', 'progressionDifficulty', 'suitsRestriction', 'hideItems', 'objective', 'nbObjective', 'tourian'],
             'Ammo and Energy': ['minorQty', 'energyQty', 'strictMinors', 'missileQty', 'superQty', 'powerBombQty'],
             'Areas and Fun': ['areaRandomization', 'lightAreaRandomization', 'areaLayout', 'doorsColorsRando', 'allowGreyDoors', 'bossRandomization', 'minimizer', 'minimizerQty', 'escapeRando', 'removeEscapeEnemies', 'funCombat', 'funMovement', 'funSuits'],
             'Patches': ['layoutPatches', 'variaTweaks', 'nerfedCharge', 'gravityBehaviour', 'itemsounds', 'elevators_speed', 'fast_doors', 'spinjumprestart', 'rando_speed', 'Infinite_Space_Jump', 'refill_before_save', 'hud', 'animals', 'No_Music', 'random_music', 'relaxed_round_robin_cf']

--- a/web/backend/randomizer.py
+++ b/web/backend/randomizer.py
@@ -263,7 +263,12 @@ class Randomizer(object):
         for var, value in randoPresetDict.items():
             if 'MultiSelect' in var:
                 randoPresetDict[var] = value.split(',')
-        randoPresetDict['objective'] = self.vars.objective.split(',')
+
+        if self.vars.objectiveRandom:
+            randoPresetDict['objective'] = self.vars.nbObjective # 0-5 or "random"
+            randoPresetDict['objectiveMultiSelect'] = self.vars.objective.split(',')
+        else:
+            randoPresetDict['objective'] = self.vars.objective.split(',')
 
         with open(jsonRandoPreset, 'w') as randoPresetFile:
             json.dump(randoPresetDict, randoPresetFile)
@@ -426,10 +431,15 @@ class Randomizer(object):
         self.session.randomizer['hud'] = self.vars.hud
         self.session.randomizer['scavNumLocs'] = self.vars.scavNumLocs
         self.session.randomizer['scavRandomized'] = self.vars.scavRandomized
+        self.session.randomizer['tourian'] = self.vars.tourian
+
         # objective is a special multi select
-        self.session.randomizer['objective'] = self.vars.objective.split(',')
-        if self.vars.objectiveMultiSelect is not None:
-            self.session.randomizer['objectiveMultiSelect'] = self.vars.objectiveMultiSelect.split(',')
+        self.session.randomizer['objectiveRandom'] = self.vars.objectiveRandom
+        if self.vars.objectiveRandom == 'true':
+            self.session.randomizer['objectiveMultiSelect'] = self.vars.objective.split(',')
+            self.session.randomizer['nbObjective'] = self.vars.nbObjective
+        else:
+            self.session.randomizer['objective'] = self.vars.objective.split(',')
 
         multis = ['majorsSplit', 'progressionSpeed', 'progressionDifficulty', 'tourian',
                   'morphPlacement', 'energyQty', 'startLocation', 'gravityBehaviour']

--- a/web/backend/randomizer.py
+++ b/web/backend/randomizer.py
@@ -198,10 +198,10 @@ class Randomizer(object):
                    'rando_speed', 'animals', 'No_Music', 'random_music',
                    'Infinite_Space_Jump', 'refill_before_save', 'hud', "scavRandomized",
                    'relaxed_round_robin_cf']
-        quantities = ['missileQty', 'superQty', 'powerBombQty', 'minimizerQty', "scavNumLocs", 'nbObjective']
+        quantities = ['missileQty', 'superQty', 'powerBombQty', 'minimizerQty', "scavNumLocs"]
         multis = ['majorsSplit', 'progressionSpeed', 'progressionDifficulty', 'tourian',
                   'morphPlacement', 'energyQty', 'startLocation', 'gravityBehaviour']
-        others = ['complexity', 'paramsFileTarget', 'seed', 'preset', 'maxDifficulty', 'objective', 'nbObjective']
+        others = ['complexity', 'paramsFileTarget', 'seed', 'preset', 'maxDifficulty', 'objective']
         validateWebServiceParams(self.request, switchs, quantities, multis, others, isJson=True)
 
         # randomize
@@ -264,10 +264,6 @@ class Randomizer(object):
             if 'MultiSelect' in var:
                 randoPresetDict[var] = value.split(',')
         randoPresetDict['objective'] = self.vars.objective.split(',')
-
-        if randoPresetDict.get('nbObjective'):
-            randoPresetDict['objectiveMultiSelect'] = randoPresetDict['objective']
-            randoPresetDict['objective'] = randoPresetDict.pop('nbObjective')
 
         with open(jsonRandoPreset, 'w') as randoPresetFile:
             json.dump(randoPresetDict, randoPresetFile)
@@ -379,7 +375,7 @@ class Randomizer(object):
                    'relaxed_round_robin_cf']
         quantities = ['missileQty', 'superQty', 'powerBombQty', 'minimizerQty', "scavNumLocs"]
         multis = ['majorsSplit', 'progressionSpeed', 'progressionDifficulty', 'tourian',
-                  'morphPlacement', 'energyQty', 'startLocation', 'gravityBehaviour']
+                  'morphPlacement', 'energyQty', 'startLocation', 'gravityBehaviour', 'objective']
         others = ['complexity', 'preset', 'randoPreset', 'maxDifficulty', 'minorQty', 'objective']
         validateWebServiceParams(self.request, switchs, quantities, multis, others)
 
@@ -432,7 +428,6 @@ class Randomizer(object):
         self.session.randomizer['scavRandomized'] = self.vars.scavRandomized
         # objective is a special multi select
         self.session.randomizer['objective'] = self.vars.objective.split(',')
-        self.session.randomizer['nbObjective'] = self.vars.nbObjective
 
         if self.vars.objectiveMultiSelect is not None:
             self.session.randomizer['objectiveMultiSelect'] = self.vars.objectiveMultiSelect.split(',')

--- a/web/backend/randomizer.py
+++ b/web/backend/randomizer.py
@@ -198,10 +198,10 @@ class Randomizer(object):
                    'rando_speed', 'animals', 'No_Music', 'random_music',
                    'Infinite_Space_Jump', 'refill_before_save', 'hud', "scavRandomized",
                    'relaxed_round_robin_cf']
-        quantities = ['missileQty', 'superQty', 'powerBombQty', 'minimizerQty', "scavNumLocs"]
+        quantities = ['missileQty', 'superQty', 'powerBombQty', 'minimizerQty', "scavNumLocs", 'nbObjective']
         multis = ['majorsSplit', 'progressionSpeed', 'progressionDifficulty', 'tourian',
                   'morphPlacement', 'energyQty', 'startLocation', 'gravityBehaviour']
-        others = ['complexity', 'paramsFileTarget', 'seed', 'preset', 'maxDifficulty', 'objective']
+        others = ['complexity', 'paramsFileTarget', 'seed', 'preset', 'maxDifficulty', 'objective', 'nbObjective']
         validateWebServiceParams(self.request, switchs, quantities, multis, others, isJson=True)
 
         # randomize
@@ -264,6 +264,10 @@ class Randomizer(object):
             if 'MultiSelect' in var:
                 randoPresetDict[var] = value.split(',')
         randoPresetDict['objective'] = self.vars.objective.split(',')
+
+        if randoPresetDict.get('nbObjective'):
+            randoPresetDict['objectiveMultiSelect'] = randoPresetDict['objective']
+            randoPresetDict['objective'] = randoPresetDict.pop('nbObjective')
 
         with open(jsonRandoPreset, 'w') as randoPresetFile:
             json.dump(randoPresetDict, randoPresetFile)
@@ -428,6 +432,8 @@ class Randomizer(object):
         self.session.randomizer['scavRandomized'] = self.vars.scavRandomized
         # objective is a special multi select
         self.session.randomizer['objective'] = self.vars.objective.split(',')
+        self.session.randomizer['nbObjective'] = self.vars.nbObjective
+
         if self.vars.objectiveMultiSelect is not None:
             self.session.randomizer['objectiveMultiSelect'] = self.vars.objectiveMultiSelect.split(',')
 

--- a/web/backend/randomizer.py
+++ b/web/backend/randomizer.py
@@ -151,8 +151,14 @@ class Randomizer(object):
         defaultMultiValues = getDefaultMultiValues()
         for key in defaultMultiValues:
             keyMulti = key + 'MultiSelect'
-            if keyMulti in self.session.randomizer:
-                defaultMultiValues[key] = self.session.randomizer[keyMulti]
+            if key == "objective":
+                if key in self.session.randomizer:
+                    defaultMultiValues[key] = self.session.randomizer[key]
+                elif keyMulti in self.session.randomizer:
+                    defaultMultiValues[key] = self.session.randomizer[keyMulti]
+            else:
+                if keyMulti in self.session.randomizer:
+                    defaultMultiValues[key] = self.session.randomizer[keyMulti]
         return defaultMultiValues
 
     # race mode
@@ -422,7 +428,6 @@ class Randomizer(object):
         self.session.randomizer['scavRandomized'] = self.vars.scavRandomized
         # objective is a special multi select
         self.session.randomizer['objective'] = self.vars.objective.split(',')
-
         if self.vars.objectiveMultiSelect is not None:
             self.session.randomizer['objectiveMultiSelect'] = self.vars.objectiveMultiSelect.split(',')
 

--- a/web/backend/randomizer.py
+++ b/web/backend/randomizer.py
@@ -264,7 +264,7 @@ class Randomizer(object):
             if 'MultiSelect' in var:
                 randoPresetDict[var] = value.split(',')
 
-        if self.vars.objectiveRandom:
+        if self.vars.objectiveRandom == 'true':
             randoPresetDict['objective'] = self.vars.nbObjective # 0-5 or "random"
             randoPresetDict['objectiveMultiSelect'] = self.vars.objective.split(',')
         else:

--- a/web/backend/randomizer.py
+++ b/web/backend/randomizer.py
@@ -151,14 +151,8 @@ class Randomizer(object):
         defaultMultiValues = getDefaultMultiValues()
         for key in defaultMultiValues:
             keyMulti = key + 'MultiSelect'
-            if key == "objective":
-                if key in self.session.randomizer:
-                    defaultMultiValues[key] = self.session.randomizer[key]
-                elif keyMulti in self.session.randomizer:
-                    defaultMultiValues[key] = self.session.randomizer[keyMulti]
-            else:
-                if keyMulti in self.session.randomizer:
-                    defaultMultiValues[key] = self.session.randomizer[keyMulti]
+            if keyMulti in self.session.randomizer:
+                defaultMultiValues[key] = self.session.randomizer[keyMulti]
         return defaultMultiValues
 
     # race mode
@@ -375,7 +369,7 @@ class Randomizer(object):
                    'relaxed_round_robin_cf']
         quantities = ['missileQty', 'superQty', 'powerBombQty', 'minimizerQty', "scavNumLocs"]
         multis = ['majorsSplit', 'progressionSpeed', 'progressionDifficulty', 'tourian',
-                  'morphPlacement', 'energyQty', 'startLocation', 'gravityBehaviour', 'objective']
+                  'morphPlacement', 'energyQty', 'startLocation', 'gravityBehaviour']
         others = ['complexity', 'preset', 'randoPreset', 'maxDifficulty', 'minorQty', 'objective']
         validateWebServiceParams(self.request, switchs, quantities, multis, others)
 

--- a/web/backend/utils.py
+++ b/web/backend/utils.py
@@ -212,7 +212,12 @@ def validateWebServiceParams(request, switchs, quantities, multis, others, isJso
             raiseHttp(400, "Wrong value for seed", isJson)
 
     if 'objective' in others:
-        objective = request.vars.objective.split(',')
+        if request.vars.objective.isdigit():
+            if not int(request.vars.objective) in range(6):
+                raiseHttp(400, "Number of objectives must be 0-5", isJson)
+            objective = request.vars.objectiveMultiSelect.split(',')
+        else:
+            objective = request.vars.objective.split(',')
         authorizedObjectives = defaultMultiValues['objective'] + ['random', 'nothing']
         for value in objective:
             if value not in authorizedObjectives:

--- a/web/backend/utils.py
+++ b/web/backend/utils.py
@@ -212,20 +212,28 @@ def validateWebServiceParams(request, switchs, quantities, multis, others, isJso
             raiseHttp(400, "Wrong value for seed", isJson)
 
     if 'objective' in others:
-        if request.vars.objective.isdigit():
-            if not int(request.vars.objective) in range(6):
-                raiseHttp(400, "Number of objectives must be 0-5", isJson)
-            objective = request.vars.objectiveMultiSelect.split(',')
-        else:
-            objective = request.vars.objective.split(',')
-        authorizedObjectives = defaultMultiValues['objective'] + ['random', 'nothing']
+        value = request.vars.objectiveRandom
+        if not request.vars.objectiveRandom in ['true', 'false']:
+            raiseHttp(400, "objectiveRandom must be either true or false", isJson)
+
+        objective = request.vars.objective.split(',')
+        authorizedObjectives = defaultMultiValues['objective'] + ['nothing']
         for value in objective:
             if value not in authorizedObjectives:
                 raiseHttp(400, "Wrong value for objective", isJson)
-        if objective == ['random']:
-            for value in request.vars.objectiveMultiSelect.split(','):
-                if value not in authorizedObjectives:
-                    raiseHttp(400, "Wrong value for objectiveMultiSelect", isJson)
+
+
+        if request.vars.objectiveRandom == 'true':
+            nbObjective = request.vars.nbObjective
+            if nbObjective.isdigit():
+                if not int(nbObjective) in range(6):
+                    raiseHttp(400, "Number of objectives must be 0-5", isJson)
+            elif nbObjective != "random":
+                raiseHttp(400, "Number of objectives must be 0-5 or \"random\"", isJson)
+        else:
+            if len(objective) > 5:
+                raiseHttp(400, "You cannot choose more than 5 objectives", isJson)
+
 
     if 'minDegree' in others:
         minDegree = getInt(request, 'minDegree', isJson)

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -313,7 +313,7 @@ function randomize(evt, elemId) {
     evt.currentTarget.className = evt.currentTarget.className.replace(" active", "");
     isActive = false;
 
-    defaultValues = {"missileQty": 3, "superQty": 2, "powerBombQty": 1, "minorQty": 100, "scavNumLocs": 10};
+    defaultValues = {"missileQty": 3, "superQty": 2, "powerBombQty": 1, "minorQty": 100, "scavNumLocs": 10, "nbObjective": 4};
 
     if(e.value.length == 0 && elemId in defaultValues) {
       e.value = defaultValues[elemId];
@@ -752,7 +752,7 @@ function getComplexity() {
 
 function setRandom() {
 {{
-    for id in ["missileQty", "superQty", "powerBombQty", "minorQty", "energyQty", "majorsSplit", "suitsRestriction", "morphPlacement", "funCombat", "funMovement", "funSuits", "progressionDifficulty", "hideItems", "strictMinors", "progressionSpeed", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "startLocation", "minimizerQty", "gravityBehaviour", "scavNumLocs", "tourian"]:
+    for id in ["missileQty", "superQty", "powerBombQty", "minorQty", "energyQty", "majorsSplit", "suitsRestriction", "morphPlacement", "funCombat", "funMovement", "funSuits", "progressionDifficulty", "hideItems", "strictMinors", "progressionSpeed", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "startLocation", "minimizerQty", "gravityBehaviour", "scavNumLocs", "tourian", "nbObjective"]:
       if id in session.randomizer and session.randomizer[id] == "random":
         response.write("  document.getElementById(\"{}Random\").click();\n".format(id), escape=False)
         if "{}MultiSelect".format(id) in session.randomizer:
@@ -858,7 +858,7 @@ function AjaxPresetCallCompleted(data) {
 
     var dataDict = {paramsFileTarget : data, "complexity": getComplexity()};
     var elems = ["seed", "preset", "raceMode", "areaLayout", "lightAreaRandomization", "removeEscapeEnemies", "layoutPatches", "variaTweaks", "nerfedCharge", "itemsounds", "elevators_speed", "fast_doors", "spinjumprestart", "rando_speed", "animals", "No_Music", "random_music", "maxDifficulty", "Infinite_Space_Jump", "refill_before_save", "minimizer", "allowGreyDoors", "hud", "scavRandomized", "relaxed_round_robin_cf"];
-    var randomElems = ["missileQty", "superQty", "powerBombQty", "minorQty", "suitsRestriction", "funCombat", "funMovement", "funSuits", "hideItems", "strictMinors", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "minimizerQty", "scavNumLocs"];
+    var randomElems = ["missileQty", "superQty", "powerBombQty", "minorQty", "suitsRestriction", "funCombat", "funMovement", "funSuits", "hideItems", "strictMinors", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "minimizerQty", "scavNumLocs", "nbObjective"];
     var multiElems = ["majorsSplit", "startLocation", "energyQty", "morphPlacement", "progressionDifficulty", "progressionSpeed", "gravityBehaviour", "tourian"];
 
     for(var i=0; i<elems.length; i++) {
@@ -1048,7 +1048,7 @@ function AjaxRandomizerCallCompleted(data) {
 
     var dataDict = {"complexity": getComplexity()};
     var elems = ["seed", "preset", "raceMode", "areaLayout", "lightAreaRandomization", "removeEscapeEnemies", "layoutPatches", "variaTweaks", "nerfedCharge", "itemsounds", "elevators_speed", "fast_doors", "spinjumprestart", "rando_speed", "animals", "No_Music", "randoPreset", "random_music", "maxDifficulty", "Infinite_Space_Jump", "refill_before_save", "minimizer", "allowGreyDoors", "hud", "scavRandomized", "relaxed_round_robin_cf"];
-    var randomElems = ["missileQty", "superQty", "powerBombQty", "minorQty", "suitsRestriction", "funCombat", "funMovement", "funSuits", "hideItems", "strictMinors", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "minimizerQty", "scavNumLocs"];
+    var randomElems = ["missileQty", "superQty", "powerBombQty", "minorQty", "suitsRestriction", "funCombat", "funMovement", "funSuits", "hideItems", "strictMinors", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "minimizerQty", "scavNumLocs", "nbObjective"];
     var multiElems = ["majorsSplit", "startLocation","energyQty", "morphPlacement", "progressionDifficulty", "progressionSpeed", "gravityBehaviour", "tourian"];
 
     for(var i=0; i<elems.length; i++) {
@@ -2444,6 +2444,11 @@ This patch is automatically enabled when using Full Countdown item split, or Maj
       content: "<p>Randomize the background music.</p>\
 <p>Patch developed by dude & flo.</p>",
       placement: "auto left"
+    },
+    {
+      element: "#nbObjectiveStep",
+      title: "Number of Objectives to access Tourian",
+      content: "<p>By default you need to complete 4 objectives from the list to access Tourian. You can choose 1-5 or enter 0 to make the number random.</p>",
     }
  ]});
 
@@ -2630,6 +2635,12 @@ def displayNumber(id, min, max, default, step="1"):
                 <td><span id="objectiveText">Objectives to access Tourian:</span></td>
                 <td>{{displayMultiSelect("objective", currentMultiValues["objective"], "", defaultMultiValues["objective"])}}</td>
                 <td id="objectiveStep"><button type="button" onclick="startTheTour(6)">?</button></td>
+              </tr>
+              <tr>
+                <td class="small"><div class="random"><button id="nbObjectiveRandom" type="button" onclick="randomize(event, 'nbObjective')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
+                <td><span id="nbObjectiveText">Number of objectives:</span></td>
+                <td>{{displayNumber("nbObjective", "1", "5", "4", "1")}}</td>
+                <td id="nbObjectiveStep"><button type="button" onclick="startTheTour(50)">?</button></td>
               </tr>
             </table>
             <table class="full">

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -860,8 +860,8 @@ function AjaxPresetCallCompleted(data) {
 
     var dataDict = {paramsFileTarget : data, "complexity": getComplexity()};
     var elems = ["seed", "preset", "raceMode", "areaLayout", "lightAreaRandomization", "removeEscapeEnemies", "layoutPatches", "variaTweaks", "nerfedCharge", "itemsounds", "elevators_speed", "fast_doors", "spinjumprestart", "rando_speed", "animals", "No_Music", "random_music", "maxDifficulty", "Infinite_Space_Jump", "refill_before_save", "minimizer", "allowGreyDoors", "hud", "scavRandomized", "relaxed_round_robin_cf"];
-    var randomElems = ["missileQty", "superQty", "powerBombQty", "minorQty", "suitsRestriction", "funCombat", "funMovement", "funSuits", "hideItems", "strictMinors", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "minimizerQty", "scavNumLocs", "nbObjective"];
-    var multiElems = ["majorsSplit", "startLocation", "energyQty", "morphPlacement", "progressionDifficulty", "progressionSpeed", "gravityBehaviour", "tourian"];
+    var randomElems = ["missileQty", "superQty", "powerBombQty", "minorQty", "suitsRestriction", "funCombat", "funMovement", "funSuits", "hideItems", "strictMinors", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "minimizerQty", "scavNumLocs", "objective"];
+    var multiElems = ["majorsSplit", "startLocation", "energyQty", "morphPlacement", "progressionDifficulty", "progressionSpeed", "gravityBehaviour", "tourian", "objective"];
 
     for(var i=0; i<elems.length; i++) {
         // if element is disabled set it to off
@@ -1050,8 +1050,8 @@ function AjaxRandomizerCallCompleted(data) {
 
     var dataDict = {"complexity": getComplexity()};
     var elems = ["seed", "preset", "raceMode", "areaLayout", "lightAreaRandomization", "removeEscapeEnemies", "layoutPatches", "variaTweaks", "nerfedCharge", "itemsounds", "elevators_speed", "fast_doors", "spinjumprestart", "rando_speed", "animals", "No_Music", "randoPreset", "random_music", "maxDifficulty", "Infinite_Space_Jump", "refill_before_save", "minimizer", "allowGreyDoors", "hud", "scavRandomized", "relaxed_round_robin_cf"];
-    var randomElems = ["missileQty", "superQty", "powerBombQty", "minorQty", "suitsRestriction", "funCombat", "funMovement", "funSuits", "hideItems", "strictMinors", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "minimizerQty", "scavNumLocs", "nbObjective"];
-    var multiElems = ["majorsSplit", "startLocation","energyQty", "morphPlacement", "progressionDifficulty", "progressionSpeed", "gravityBehaviour", "tourian"];
+    var randomElems = ["missileQty", "superQty", "powerBombQty", "minorQty", "suitsRestriction", "funCombat", "funMovement", "funSuits", "hideItems", "strictMinors", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "minimizerQty", "scavNumLocs", "objective"];
+    var multiElems = ["majorsSplit", "startLocation","energyQty", "morphPlacement", "progressionDifficulty", "progressionSpeed", "gravityBehaviour", "objective", "tourian"];
 
     for(var i=0; i<elems.length; i++) {
        dataDict[elems[i]] = document.getElementById(elems[i]).value;
@@ -1092,8 +1092,13 @@ function AjaxRandomizerCallCompleted(data) {
 function getSpecialValues(dataDict) {
     // special case for objectives multiselect
     if(isElemIdRandom("objective")) {
+      // Number of objectives can be controlled when objectives is random
+      if (!isElemIdRandom("nbObjective")) {
+        dataDict.objective = document.getElementById("nbObjective").value
+      } else {
         dataDict["objective"] = "random";
         dataDict["objectiveMultiSelect"] = $("#objectiveMultiSelect").val().join();
+      }
     } else {
         var objectives = get_selected_objectives();
         if(objectives.length == 0) {

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -1805,6 +1805,11 @@ The vanilla ROM is stored in the browser local storage and is never sent to our 
 <p>Click on the dice button to randomize custom objectives. You can choose which objectives are available for the randomizer to choose from. The randomizer will choose between 1 and 5 objectives from the list (between 1 and 4 if Scavenger Hunt). To know the list of randomized objectives in-game a new pause screen has been added:<br/><img src=\"/solver/static/images/help/objectives.png\" alt=\"objectives.png\" title=\"objectives.png\"/></p>"
     },
     {
+      element: "#nbObjectiveStep",
+      title: "Number of Objectives to access Tourian",
+      content: "<p>By default you need to complete 4 objectives from the list to access Tourian. You can choose 1-5 or enter 0 to make the number random.</p>",
+    },
+    {
       element: "#tourianStep",
       title: "Endgame Tourian",
       content: "<p>Choose endgame <a href=\"https://metroid.fandom.com/wiki/Tourian\" target=\"_blank\">Tourian</a> behaviour:\
@@ -2445,16 +2450,23 @@ This patch is automatically enabled when using Full Countdown item split, or Maj
 <p>Patch developed by dude & flo.</p>",
       placement: "auto left"
     },
-    {
-      element: "#nbObjectiveStep",
-      title: "Number of Objectives to access Tourian",
-      content: "<p>By default you need to complete 4 objectives from the list to access Tourian. You can choose 1-5 or enter 0 to make the number random.</p>",
-    }
  ]});
 
   // Initialize the tour
   tour.init();
 
+  if (typeof step === "object") {
+    // step is an event, not a number. Get ID from parent element
+    let parent = event.target.parentNode
+    step = parent.id
+    while (!step) {
+        parent = parent.previousElementSibling
+        step = parent.id
+    }
+  }
+  if (typeof step === 'string') {
+    step = tour._options.steps.findIndex((tour_step) => tour_step.element === `#${step}`)
+  }
   // Start the tour
   if(step != -1) {
     tour.goTo(step);
@@ -2571,7 +2583,7 @@ def displayNumber(id, min, max, default, step="1"):
             <table class="full">
               <colgroup><col class="half" /><col class="half" /></colgroup>
               <tr>
-              <td>Last generated seed permalink:</td><td><span id="permalink"></span></td><td id="permalinkStep"><button type="button" onclick="startTheTour(0)">?</button></td>
+              <td>Last generated seed permalink:</td><td><span id="permalink"></span></td><td id="permalinkStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr>
                 <td>Vanilla Super Metroid ROM:</td>
@@ -2583,7 +2595,7 @@ def displayNumber(id, min, max, default, step="1"):
                      Vanilla ROM already loaded
                    </div>
                 </td>
-                <td id="romStep"><button type="button" onclick="startTheTour(1)">?</button></td>
+                <td id="romStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr>
                 <td>Settings Preset:</td>
@@ -2603,12 +2615,12 @@ def displayNumber(id, min, max, default, step="1"):
 }}
                 </select>
                 </td>
-                <td id="randoPresetStep"><button type="button" onclick="startTheTour(2)">?</button></td>
+                <td id="randoPresetStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr id="raceModeVisibility">
                 <td>{{displayCheckbox("raceMode")}}<span id="raceModeText">Race Mode</span></td>
                 <td></td>
-                <td id="raceStep"><button type="button" onclick="startTheTour(3)">?</button></td>
+                <td id="raceStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <br/>
@@ -2619,13 +2631,13 @@ def displayNumber(id, min, max, default, step="1"):
                 <td class="small"></td>
                 <td>Randomizer seed:</td>
                 <td>{{displayNumber("seed", "0", maxsize, "0")}}</td>
-                <td id="seedStep"><button type="button" onclick="startTheTour(4)">?</button></td>
+                <td id="seedStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr>
                 <td class="small"></td>
                 <td>Skills Preset: <span class="rightStep"><a href="javascript:DoPost()">What's in the logic for this skills preset ?</a><span></td><!-- ' -->
                 <td>{{=SELECT(OPTGROUP(*stdPresets, **dict(_label="Standard presets")), OPTGROUP(*tourPresets, **dict(_label="Tournament presets")), OPTGROUP(*comPresets, **dict(_label="Community presets")), **dict(_name="preset", _id="preset", value=session.randomizer["preset"], _class="chzn-select"))}}</td>
-                <td id="presetStep"><button type="button" onclick="startTheTour(5)">?</button></td>
+                <td id="presetStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <table class="full" id="objectivesVisibility">
@@ -2634,13 +2646,13 @@ def displayNumber(id, min, max, default, step="1"):
                 <td class="small"><div class="random"><button id="objectiveRandom" type="button" onclick="randomizeObjective(event)" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="objectiveText">Objectives to access Tourian:</span></td>
                 <td>{{displayMultiSelect("objective", currentMultiValues["objective"], "", defaultMultiValues["objective"])}}</td>
-                <td id="objectiveStep"><button type="button" onclick="startTheTour(6)">?</button></td>
+                <td id="objectiveStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr>
                 <td class="small"><div class="random"><button id="nbObjectiveRandom" type="button" onclick="randomize(event, 'nbObjective')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="nbObjectiveText">Number of objectives:</span></td>
                 <td>{{displayNumber("nbObjective", "1", "5", "4", "1")}}</td>
-                <td id="nbObjectiveStep"><button type="button" onclick="startTheTour(50)">?</button></td>
+                <td id="nbObjectiveStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <table class="full">
@@ -2649,19 +2661,19 @@ def displayNumber(id, min, max, default, step="1"):
                 <td class="small"><div class="random"><button id="tourianRandom" type="button" onclick="randomize(event, 'tourian')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="tourianText">Endgame behaviour with Tourian:</span></td>
                 <td>{{displayMultiSelect("tourian", currentMultiValues["tourian"], "Vanilla", defaultMultiValues["tourian"])}}</td>
-                <td id="tourianStep"><button type="button" onclick="startTheTour(7)">?</button></td>
+                <td id="tourianStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr>
                 <td class="small"><div class="random"><button id="startLocationRandom" type="button" onclick="randomize(event, 'startLocation')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="startLocationText">Start location:</span></td>
                 <td>{{displayMultiSelect("startLocation", currentMultiValues["startLocation"], "Landing Site", defaultMultiValues["startLocation"])}}</td>
-                <td id="StartLocationStep"><button type="button" onclick="startTheTour(8)">?</button></td>
+                <td id="StartLocationStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr>
                 <td class="small"><div class="random"><button id="majorsSplitRandom" type="button" onclick="randomize(event, 'majorsSplit')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="majorsSplitText">Majors Split:</span></td>
                 <td>{{displayMultiSelect("majorsSplit", currentMultiValues["majorsSplit"], "Full", defaultMultiValues["majorsSplit"])}}</td>
-                <td id="majorsSplitStep"><button type="button" onclick="startTheTour(9)">?</button></td>
+                <td id="majorsSplitStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <table class="full" id="scavengerParams">
@@ -2670,9 +2682,9 @@ def displayNumber(id, min, max, default, step="1"):
                 <td class="small"><div class="random"><button id="scavNumLocsRandom" type="button" onclick="randomize(event, 'scavNumLocs')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td id="scavNumLocsStep"><span id="scavNumLocsText">Mandatory locations to visit:</span></td>
                 <td>{{displayNumber("scavNumLocs", "4", "17", "10", "1")}}</td>
-                <td><button type="button" onclick="startTheTour(10)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 <td id="scavRandomizedStep">{{displayCheckbox("scavRandomized")}}Randomize items in mandatory locations</td>
-                <td><button type="button" onclick="startTheTour(11)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <table class="full">
@@ -2681,7 +2693,7 @@ def displayNumber(id, min, max, default, step="1"):
                 <td class="small"></td>
                 <td><span id="maxDifficultyText">Maximum difficulty for picking up an item:</span></td>
                 <td>{{displaySelect("maxDifficulty", ['no difficulty cap', 'easy', 'medium', 'hard', 'harder', 'hardcore', 'mania'], "hardcore")}}</td>
-                <td id="maxDifficultyStep"><button type="button" onclick="startTheTour(12)">?</button></td>
+                <td id="maxDifficultyStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr>
                 <td class="small"><div class="random"><button id="progressionSpeedRandom" type="button" onclick="randomize(event, 'progressionSpeed')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
@@ -2689,29 +2701,29 @@ def displayNumber(id, min, max, default, step="1"):
                 <td class="half">
                   {{displayMultiSelect("progressionSpeed", currentMultiValues["progressionSpeed"], "medium", defaultMultiValues["progressionSpeed"])}}
                 </td>
-                <td id="progSpeedStep"><button type="button" onclick="startTheTour(13)">?</button></td>
+                <td id="progSpeedStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr id="progDiffVisibility">
                 <td class="small"><div class="random"><button id="progressionDifficultyRandom" type="button" onclick="randomize(event, 'progressionDifficulty')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td class="half"><span id="progressionDifficultyText">Progression difficulty:</span></td>
                 <td class="half">{{displayMultiSelect("progressionDifficulty", currentMultiValues["progressionDifficulty"], "normal", defaultMultiValues["progressionDifficulty"])}}</td>
-                <td id="progDiffStep"><button type="button" onclick="startTheTour(14)">?</button></td>
+                <td id="progDiffStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr id="morphPlacementVisibility">
                 <td class="small"><div class="random"><button id="morphPlacementRandom" type="button" onclick="randomize(event, 'morphPlacement')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td class="half"><span id="morphPlacementText">Morph Placement:</span></td>
                 <td class="half">{{displayMultiSelect("morphPlacement", currentMultiValues["morphPlacement"], "normal", defaultMultiValues["morphPlacement"])}}</td>
-                <td id="morphPlacementStep"><button type="button" onclick="startTheTour(15)">?</button></td>
+                <td id="morphPlacementStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr id="suitsRestrictionVisibility">
                 <td class="small"><div class="random"><button id="suitsRestrictionRandom" type="button" onclick="randomize(event, 'suitsRestriction')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td colspan="2">{{displayCheckbox("suitsRestriction")}}<span id="suitsRestrictionText">Suits restriction</span></td>
-                <td id="suitsRestrictionStep"><button type="button" onclick="startTheTour(16)">?</button></td>
+                <td id="suitsRestrictionStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr id="hideItemsVisibility">
                 <td class="small"><div class="random"><button id="hideItemsRandom" type="button" onclick="randomize(event, 'hideItems')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td colspan="2">{{displayCheckbox("hideItems")}}<span id="hideItemsText">Hide some items</span></td>
-                <td id="hideItemsStep"><button type="button" onclick="startTheTour(17)">?</button></td>
+                <td id="hideItemsStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <div id="ammoVisibility">
@@ -2721,13 +2733,13 @@ def displayNumber(id, min, max, default, step="1"):
                 <tr id="strictMinorsVisibility">
                   <td class="small"><div class="random"><button id="strictMinorsRandom" type="button" onclick="randomize(event, 'strictMinors')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td colspan="2">{{displayCheckbox("strictMinors")}}<span id="strictMinorsText">Strict Minors distribution</span></td>
-                  <td id="strictMinorsStep"><button type="button" onclick="startTheTour(18)">?</button></td>
+                  <td id="strictMinorsStep"><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
                 <tr id="missileQtyVisibility">
                   <td class="small"><div class="random"><button id="missileQtyRandom" type="button" onclick="randomize(event, 'missileQty')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td><span id="missileQtyText">Proportion of Missiles <img src="/solver/static/images/tracker/inventory/Missile.png" class="width: 32px"/>:</span></td>
                   <td>{{displayNumber("missileQty", "1", "9", "3", "0.1")}}</td>
-                  <td id="missileQtyStep"><button type="button" onclick="startTheTour(19)">?</button></td>
+                  <td id="missileQtyStep"><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
                 <tr id="superQtyVisibility">
                   <td class="small"><div class="random"><button id="superQtyRandom" type="button" onclick="randomize(event, 'superQty')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
@@ -2743,13 +2755,13 @@ def displayNumber(id, min, max, default, step="1"):
                   <td class="small"><div class="random"><button id="minorQtyRandom" type="button" onclick="randomize(event, 'minorQty')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td><span id="minorQtyText">Percentage of minors (<img src="/solver/static/images/tracker/inventory/Missile.png" class="width: 32px"/>/<img src="/solver/static/images/tracker/inventory/Super.png" class="width: 32px"/>/<img src="/solver/static/images/tracker/inventory/PowerBomb.png" class="width: 32px"/>) available:</span></td>
                   <td>{{displayNumber("minorQty", "7", "100", "100")}}</td>
-                  <td id="minorQtyStep"><button type="button" onclick="startTheTour(20)">?</button></td>
+                  <td id="minorQtyStep"><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
                 <tr>
                   <td class="small"><div class="random"><button id="energyQtyRandom" type="button" onclick="randomize(event, 'energyQty')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td><span id="energyQtyText">Quantity of Energy <img src="/solver/static/images/tracker/inventory/ETank.png" class="width: 32px"/> / Reserve Tanks <img src="/solver/static/images/tracker/inventory/Reserve.png" class="width: 32px"/> available:</span></td>
                   <td>{{displayMultiSelect("energyQty", currentMultiValues["energyQty"], "vanilla", defaultMultiValues["energyQty"])}}</td>
-                  <td id="energyQtyStep"><button type="button" onclick="startTheTour(21)">?</button></td>
+                  <td id="energyQtyStep"><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
             </div>
@@ -2764,9 +2776,9 @@ def displayNumber(id, min, max, default, step="1"):
               <tr>
                 <td class="small"><div class="random"><button id="areaRandomizationRandom" type="button" onclick="randomize(event, 'areaRandomization')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td class="half" id="areaRandomizationStep">{{displayCheckbox("areaRandomization")}}<span id="areaRandomizationText">Areas randomization</span></td>
-                <td><button type="button" onclick="startTheTour(22)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 <td class="full" id="lightAreaRandomizationStep">{{displayCheckbox("lightAreaRandomization")}}<span id="lightAreaRandomizationText">Light Areas randomization</span></td>
-                <td><button type="button" onclick="startTheTour(23)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <table id="areaLayoutVisibility" class="full">
@@ -2774,7 +2786,7 @@ def displayNumber(id, min, max, default, step="1"):
               <tr>
                 <td id="areaLayoutStep">{{displayCheckbox("areaLayout", False)}}<span id="areaLayoutText">Additional layout patches for easier navigation</span></td>
                 <td></td>
-                <td><button type="button" onclick="startTheTour(24)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
 
@@ -2783,9 +2795,9 @@ def displayNumber(id, min, max, default, step="1"):
               <tr>
                 <td class="small"><div class="random"><button id="doorsColorsRandoRandom" type="button" onclick="randomize(event, 'doorsColorsRando')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td class="half" id="doorsColorsRandoStep">{{displayCheckbox("doorsColorsRando")}}<span id="doorsColorsRandoText">Randomize the color of Red/Green/Yellow doors</span></td>
-                <td><button type="button" onclick="startTheTour(25)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 <td class="half" id="doorsColorsGreyStep">{{displayCheckbox("allowGreyDoors")}}Allow some doors to be randomized to grey doors</td>
-                <td><button type="button" onclick="startTheTour(26)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <h4>Bosses Randomization</h4>
@@ -2796,14 +2808,14 @@ def displayNumber(id, min, max, default, step="1"):
               <tr>
                 <td class="small"><div class="random"><button id="bossRandomizationRandom" type="button" onclick="randomize(event, 'bossRandomization')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td colspan="3" class="full" id="bossRandomizationStep">{{displayCheckbox("bossRandomization")}}<span id="bossRandomizationText">Bosses randomization</span></td>
-                <td><button type="button" onclick="startTheTour(27)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr>
                 <td class="small"><div class="random"><button id="minimizerQtyRandom" type="button" onclick="randomizeMinimizer(event)" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td id="minimizerStep" class="half">{{displayCheckbox("minimizer")}}<span id="minimizerText">Boss rush, aka Minimizer</span></td>
                 <td class="quarter"><span id="minimizerQtyText">Number of locations:</span></td>
                 <td class="quarter">{{displayNumber("minimizerQty", "30", "100", "45", "1")}}</td>
-                <td><button type="button" onclick="startTheTour(28)">?</button></td>
+                <td><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>
             <div id="escapeRandoVisibility">
@@ -2812,9 +2824,9 @@ def displayNumber(id, min, max, default, step="1"):
                 <tr>
                   <td class="small"><div class="random"><button id="escapeRandoRandom" type="button" onclick="randomize(event, 'escapeRando')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td class="half" id="escapeRandoStep">{{displayCheckbox("escapeRando", False)}}<span id="escapeRandoText">Randomize the escape sequence</span></td>
-                  <td><button type="button" onclick="startTheTour(29)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                   <td class="half" id="removeEscapeEnemiesStep">{{displayCheckbox("removeEscapeEnemies", False)}}<span id="removeEscapeEnemiesText">Remove enemies during randomized escape sequence</span></td>
-                  <td><button type="button" onclick="startTheTour(30)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
             </div>
@@ -2827,15 +2839,15 @@ def displayNumber(id, min, max, default, step="1"):
                 <tr>
                   <td class="small" id="funCombatStep"><div class="random"><button id="funCombatRandom" type="button" onclick="randomize(event, 'funCombat')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td class="third">{{displayCheckbox("funCombat")}}<span id="funCombatText">Super Fun Combat</span></td>
-                  <td><button type="button" onclick="startTheTour(31)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
 
                   <td class="small" id="funMovementStep"><div class="random"><button id="funMovementRandom" type="button" onclick="randomize(event, 'funMovement')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td class="third">{{displayCheckbox("funMovement")}}<span id="funMovementText">Super Fun Movement</span></td>
-                  <td><button type="button" onclick="startTheTour(32)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
 
                   <td class="small" id="funSuitsStep"><div class="random"><button id="funSuitsRandom" type="button" onclick="randomize(event, 'funSuits')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td class="third">{{displayCheckbox("funSuits")}}<span id="funSuitsText">Suitless</span></td>
-                  <td><button type="button" onclick="startTheTour(33)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
             </div>
@@ -2844,7 +2856,7 @@ def displayNumber(id, min, max, default, step="1"):
               <p>Some patches are applied by default, use the 'advanced' tab to see them.</p>
             </div>
             <div id="patchesVisibility">
-              <h4 id="patchesStep">Patches<span class="rightStep"><button type="button" onclick="startTheTour(34)">?</button></span></h4>
+              <h4 id="patchesStep">Patches<span class="rightStep"><button type="button" onclick="startTheTour('patchesStep')">?</button></span></h4>
               <p id="mainPatchesTextVisibility">
                 The bug fix <a href="https://itemrando.supermetroid.run/information" target="_blank">patches</a> from Total Item Randomizer are included by default.
               </p>
@@ -2855,33 +2867,33 @@ def displayNumber(id, min, max, default, step="1"):
               <table class="full" id="mainPatchesVisibility">
                 <tr>
                   <td id="layoutPatchesStep" class="half">{{displayCheckbox("layoutPatches", True)}} Anti-softlock layout patches</td>
-                  <td><button type="button" onclick="startTheTour(35)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                   <td id="variaTweaksStep" class="half">{{displayCheckbox("variaTweaks", True)}} VARIA tweaks</td>
-                  <td><button type="button" onclick="startTheTour(36)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
               <table class="full" id="nerfedChargeVisibility">
-                <tr id="nerfedChargeStep">
-                  <td class="half">
+                <tr>
+                  <td class="half" id="nerfedChargeStep">
                     {{displayCheckbox("nerfedCharge")}}
                     Nerfed Charge Beam available from the start
                   </td>
-                  <td><button type="button" onclick="startTheTour(37)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                   <td id="relaxed_round_robin_cfStep" class="half">
                     {{displayCheckbox("relaxed_round_robin_cf")}}
                     Relaxed Round Robin Crystal Flash
                   </td>
-                  <td><button type="button" onclick="startTheTour(38)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
               <table class="full" id="gravityBehaviourVisibility">
-                <tr id="gravityBehaviourStep">
-                  <td class="small"><div class="random"><button id="gravityBehaviourRandom" type="button" onclick="randomize(event, 'gravityBehaviour')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
+                <tr>
+                  <td class="small" id="gravityBehaviourStep"><div class="random"><button id="gravityBehaviourRandom" type="button" onclick="randomize(event, 'gravityBehaviour')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                   <td class="half"><span id="gravityBehaviourText">Suits properties</span></td>
                   <td class="half">
                     {{displayMultiSelect("gravityBehaviour", currentMultiValues["gravityBehaviour"], "Balanced", defaultMultiValues["gravityBehaviour"])}}
                   </td>
-                  <td><button type="button" onclick="startTheTour(39)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
               <table class="full">
@@ -2894,7 +2906,7 @@ def displayNumber(id, min, max, default, step="1"):
                     {{displayCheckbox("itemsounds")}}
                     Remove fanfare when picking up an item
                   </td>
-                  <td><button type="button" onclick="startTheTour(40)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                   <td id="ElevatorDoorsStep" class="quarter">
                     {{displayCheckbox("fast_doors")}}
                     Accelerate doors
@@ -2903,7 +2915,7 @@ def displayNumber(id, min, max, default, step="1"):
                     {{displayCheckbox("elevators_speed")}}
                     Accelerate elevators
                   </td>
-                  <td><button type="button" onclick="startTheTour(41)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
               <table class="full">
@@ -2912,12 +2924,12 @@ def displayNumber(id, min, max, default, step="1"):
                     {{displayCheckbox("spinjumprestart")}}
                     Spin jump restart (a.k.a. Respin)
                   </td>
-                  <td><button type="button" onclick="startTheTour(42)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                   <td id="rando_speedStep" class="half">
                     {{displayCheckbox("rando_speed")}}
                      Momentum conservation (a.k.a. Speedkeep)
                   </td>
-                  <td><button type="button" onclick="startTheTour(43)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
               <table class="full" id="helperPatchesVisibility">
@@ -2926,19 +2938,19 @@ def displayNumber(id, min, max, default, step="1"):
                     {{displayCheckbox("Infinite_Space_Jump")}}
                     Infinite Space Jump
                   </td>
-                  <td><button type="button" onclick="startTheTour(44)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                   <td id="refill_before_saveStep" class="half">
                     {{displayCheckbox("refill_before_save")}}
                      Refill energy and ammo when saving
                   </td>
-                  <td><button type="button" onclick="startTheTour(45)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
                 <tr>
                   <td id="hudStep" class="half">
                     {{displayCheckbox("hud")}}
                      VARIA HUD
                   </td>
-                  <td><button type="button" onclick="startTheTour(46)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                   <td></td>
                   <td></td>
                 </tr>
@@ -2949,13 +2961,13 @@ def displayNumber(id, min, max, default, step="1"):
               </table>
               <table class="full" id="miscVisibility">
                 <colgroup><col class="half" /><col class="half" /></colgroup>
-                <tr id="animalsStep">
-                  <td>
+                <tr>
+                  <td id="animalsStep">
                     {{displayCheckbox("animals")}}
                     <span id="animalsText">Save the animals surprise</span>
                   </td>
                   <td></td>
-                  <td><button type="button" onclick="startTheTour(47)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
               <table class="full" id="musicVisibility">
@@ -2964,12 +2976,12 @@ def displayNumber(id, min, max, default, step="1"):
                     {{displayCheckbox("No_Music")}}
                     Disable background music
                   </td>
-                  <td><button type="button" onclick="startTheTour(48)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                   <td id="random_musicStep" class="half">
                     {{displayCheckbox("random_music")}}
                     Randomize background music
                   </td>
-                  <td><button type="button" onclick="startTheTour(49)">?</button></td>
+                  <td><button type="button" onclick="startTheTour(event)">?</button></td>
                 </tr>
               </table>
             </div>

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -713,8 +713,12 @@ function randomizeObjective(evt) {
             objective_change(null, {deselected: selectedArray[i]}, true);
         }
 
+        var all_objectives = getAllObjectives();
         if (backup_values.length === 0) {
-            backup_values = getAllObjectives()
+            backup_values = all_objectives
+        }
+        if (backup_values.length >= all_objectives.length) {
+            backup_values = backup_values.filter(s => s !== 'collect 100% items');
         }
         $("#objectiveMultiSelect").val(backup_values).trigger("chosen:updated");
     }

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -820,6 +820,7 @@ function setObjective() {
 
     $("#objectiveMultiSelect").val(selected_objectives).trigger("chosen:updated");
     $("#objectiveMultiSelect").on('change', objective_change);
+    objective_change(undefined, {selected: {}})
 }
 
 function setComplexity() {

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -656,10 +656,12 @@ function setMaxObjective(isRandom) {
         // no limit
         $("#objectiveMultiSelect").chosen("destroy");
         $("#objectiveMultiSelect").chosen({max_selected_options: Infinity, width: '100%'})
+        $("#nbObjectiveVisiblity").show();
     } else {
         // limit to 5 objectives (4 in scav hunt)
         $("#objectiveMultiSelect").chosen("destroy");
         $("#objectiveMultiSelect").chosen({max_selected_options: max_objectives, width: '100%'})
+        $("#nbObjectiveVisiblity").hide();
     }
 }
 
@@ -2477,17 +2479,6 @@ This patch is automatically enabled when using Full Countdown item split, or Maj
 function DoPost(){
     $.redirect("/presets", { action: "Load", currenttab: "Techniques1", preset: document.getElementById("preset").value }, "POST", "_blank");
 }
-
-$(() => {
-    $('#objectiveMultiSelect').chosen().change(e => {
-        if ($('#objectiveMultiSelect').chosen().val().length > 1) {
-            $("#nbObjectiveVisiblity").show();
-        } else {
-            $("#nbObjectiveVisiblity").hide();
-        }
-    })
-    $('#objectiveMultiSelect').chosen().change();
-})
 </script>
 {{
 def displayCheckbox(id, defaultTrue=False):

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -2477,6 +2477,16 @@ This patch is automatically enabled when using Full Countdown item split, or Maj
 function DoPost(){
     $.redirect("/presets", { action: "Load", currenttab: "Techniques1", preset: document.getElementById("preset").value }, "POST", "_blank");
 }
+
+$(() => {
+    $('#objectiveMultiSelect').chosen().change(e => {
+        if ($('#objectiveMultiSelect').chosen().val().length > 1) {
+            $("#nbObjectiveVisiblity").show()
+        } else {
+            $("#nbObjectiveVisiblity").hide()
+        }
+    })
+})
 </script>
 {{
 def displayCheckbox(id, defaultTrue=False):
@@ -2648,7 +2658,7 @@ def displayNumber(id, min, max, default, step="1"):
                 <td>{{displayMultiSelect("objective", currentMultiValues["objective"], "", defaultMultiValues["objective"])}}</td>
                 <td id="objectiveStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
-              <tr>
+              <tr id="nbObjectiveVisiblity">
                 <td class="small"><div class="random"><button id="nbObjectiveRandom" type="button" onclick="randomize(event, 'nbObjective')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="nbObjectiveText">Number of objectives:</span></td>
                 <td>{{displayNumber("nbObjective", "1", "5", "4", "1")}}</td>

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -2481,11 +2481,12 @@ function DoPost(){
 $(() => {
     $('#objectiveMultiSelect').chosen().change(e => {
         if ($('#objectiveMultiSelect').chosen().val().length > 1) {
-            $("#nbObjectiveVisiblity").show()
+            $("#nbObjectiveVisiblity").show();
         } else {
-            $("#nbObjectiveVisiblity").hide()
+            $("#nbObjectiveVisiblity").hide();
         }
     })
+    $('#objectiveMultiSelect').chosen().change();
 })
 </script>
 {{

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -619,9 +619,10 @@ var removed_objectives = [];
 console.log("objectives_types: boss: "+objectives_types['boss']);
 console.log("objectives_types: miniboss: "+objectives_types['miniboss']);
 
-function objective_change(e, params) {
+function objective_change(e, params, force) {
     // if random is set do nothing
-    if(isElemIdRandom("objective")) {
+    // force is used when the objective is changed to random and we need to unselect everything
+    if(isElemIdRandom("objective") && !force) {
         return;
     }
 
@@ -641,7 +642,7 @@ function objective_change(e, params) {
         for(var j=0; j<copy_removed_objectives.length; j++) {
             var toAdd = copy_removed_objectives[j];
             console.log("  check to add obj "+toAdd+" from removed objectives");
-            if(can_add_to_unselected(toAdd)) {
+            if(can_add_to_unselected(toAdd) || force) {
                 add_objective_to_unselected(toAdd);
             }
         }
@@ -670,7 +671,9 @@ var objectiveBackup = {
     false: {{ response.write("{}".format(session.randomizer.get('objective', [])), escape=False) }},
 }
 
-function randomizeObjective(evt, takeBackup=true) {
+var takeBackup = false;
+
+function randomizeObjective(evt) {
     var isActive;
     var wasRandom = isElemRandom(evt.currentTarget)
 
@@ -679,6 +682,8 @@ function randomizeObjective(evt, takeBackup=true) {
         objectiveBackup[wasRandom] = get_selected_objectives()
     }
 
+    takeBackup = true;
+    var selectedArray = get_selected_objectives();
     if(wasRandom) {
         evt.currentTarget.className = evt.currentTarget.className.replace(" active", "");
         isActive = false;
@@ -694,7 +699,6 @@ function randomizeObjective(evt, takeBackup=true) {
         removed_objectives = [];
 
         // handle exclusions for currently selected values
-        var selectedArray = get_selected_objectives();
         for(var i=0; i<selectedArray.length; i++) {
             objective_change(null, {selected: selectedArray[i]});
         }
@@ -703,6 +707,12 @@ function randomizeObjective(evt, takeBackup=true) {
         isActive = true;
         setMaxObjective(true);
         var backup_values = objectiveBackup.true
+
+        // undo exclusions since random allows for all objectives
+        for(var i=0; i<selectedArray.length; i++) {
+            objective_change(null, {deselected: selectedArray[i]}, true);
+        }
+
         if (backup_values.length === 0) {
             backup_values = getAllObjectives()
         }
@@ -780,38 +790,35 @@ function setRandom() {
 }
 
 function setObjective() {
+    // called once when page loads to load objective values into form
     // always display objectives multi select
     var select = document.getElementById("objective");
     var multi = document.getElementById("objectiveMultiSelectDiv");
+
     select.style.display = "none";
     multi.style.display = "block";
     setMaxObjective(isElemRandom(document.getElementById("objectiveRandom")));
 
     // at start all objectives are displayed as selected even though they're not...
-    var objective = {{response.write(session.randomizer.get('objective', []), escape=False)}}
-    var objective_multi = {{response.write(session.randomizer.get("objectiveMultiSelect", []), escape=False)}}
-    var objective_random = false
+    var objective_random = "{{response.write(session.randomizer.get("objectiveRandom"))}}" == "true"
+    var objective_number = "{{response.write(session.randomizer.get("nbObjective", 4))}}"
 
-    if (['0', 'random'].includes(objective[0])) {
-        document.getElementById('nbObjectiveRandom').click()
-        objective_random = true
-    } else if (['1', '2', '3','4','5'].includes(objective[0])) {
-        document.getElementById('nbObjective').value = objective[0]
-        objective_random = true
-    } else {
-        objective_multi = objective
-    }
-
+    var selected_objectives = objectiveBackup[objective_random]
     if (objective_random) {
         // handle exclusions for currently selected values
         document.getElementById('objectiveRandom').click()
-        var selectedArray = get_selected_objectives();
-        for(var i=0; i<selectedArray.length; i++) {
-            objective_change(null, {selected: selectedArray[i]});
+        for(var i=0; i<selected_objectives.length; i++) {
+            objective_change(null, {selected: selected_objectives[i]});
         }
     }
-    $("#objectiveMultiSelect").val(objective_multi).trigger("chosen:updated");
 
+    if (['0', 'random'].includes(objective_number)) {
+        document.getElementById('nbObjectiveRandom').click()
+    } else {
+        document.getElementById('nbObjective').value = objective_number
+    }
+
+    $("#objectiveMultiSelect").val(selected_objectives).trigger("chosen:updated");
     $("#objectiveMultiSelect").on('change', objective_change);
 }
 
@@ -2548,8 +2555,10 @@ def displayMultiSelect(id, selectedValues, default, multipleValues):
 def displayNumber(id, min, max, default, step="1"):
   if id in session.randomizer:
     value = session.randomizer[id]
-    if value == 'random' and id == 'nbObjective':
-      value = 0
+    if value in ['0', 'random'] and id == 'nbObjective':
+      # "random" for this is actually 0, but the input field is 1-5
+      # since the value only matters when the dice is not checked, set to the default value: 4
+      value = 4
       pass
   else:
     value = default
@@ -2675,7 +2684,7 @@ def displayNumber(id, min, max, default, step="1"):
               <tr id="nbObjectiveVisiblity">
                 <td class="small"><div class="random"><button id="nbObjectiveRandom" type="button" onclick="randomize(event, 'nbObjective')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="nbObjectiveText">Number of objectives:</span></td>
-                <td>{{displayNumber("nbObjective", "0", "5", "4", "1")}}</td>
+                <td>{{displayNumber("nbObjective", "1", "5", "4", "1")}}</td>
                 <td id="nbObjectiveStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -754,7 +754,7 @@ function getComplexity() {
 
 function setRandom() {
 {{
-    for id in ["missileQty", "superQty", "powerBombQty", "minorQty", "energyQty", "majorsSplit", "suitsRestriction", "morphPlacement", "funCombat", "funMovement", "funSuits", "progressionDifficulty", "hideItems", "strictMinors", "progressionSpeed", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "startLocation", "minimizerQty", "gravityBehaviour", "scavNumLocs", "tourian", "nbObjective"]:
+    for id in ["missileQty", "superQty", "powerBombQty", "minorQty", "energyQty", "majorsSplit", "suitsRestriction", "morphPlacement", "funCombat", "funMovement", "funSuits", "progressionDifficulty", "hideItems", "strictMinors", "progressionSpeed", "areaRandomization", "doorsColorsRando", "bossRandomization", "escapeRando", "startLocation", "minimizerQty", "gravityBehaviour", "scavNumLocs", "tourian"]:
       if id in session.randomizer and session.randomizer[id] == "random":
         response.write("  document.getElementById(\"{}Random\").click();\n".format(id), escape=False)
         if "{}MultiSelect".format(id) in session.randomizer:
@@ -774,30 +774,29 @@ function setObjective() {
     setMaxObjective(isElemRandom(document.getElementById("objectiveRandom")));
 
     // at start all objectives are displayed as selected even though they're not...
-    var sessionObjectives = {{
-if session.randomizer["objective"]:
-    if type(session.randomizer["objective"]) == list:
-        response.write(session.randomizer["objective"], escape=False)
-    else:
-        response.write(session.randomizer["objective"].split(','), escape=False)
-        pass
-else:
-    response.write("[]", escape=False)
-    pass
-}};
+    var objective = {{response.write(session.randomizer.get('objective', []), escape=False)}}
+    var objective_multi = {{response.write(session.randomizer.get("objectiveMultiSelect", []), escape=False)}}
+    var objective_random = false
 
+    if (['0', 'random'].includes(objective[0])) {
+        document.getElementById('nbObjectiveRandom').click()
+        objective_random = true
+    } else if (['1', '2', '3','4','5'].includes(objective[0])) {
+        document.getElementById('nbObjective').value = objective[0]
+        objective_random = true
+    } else {
+        objective_multi = objective
+    }
 
-    if(sessionObjectives != "random") {
-        $("#objectiveMultiSelect").val(sessionObjectives).trigger("chosen:updated");
-
+    if (objective_random) {
         // handle exclusions for currently selected values
+        document.getElementById('objectiveRandom').click()
         var selectedArray = get_selected_objectives();
         for(var i=0; i<selectedArray.length; i++) {
             objective_change(null, {selected: selectedArray[i]});
         }
-    } else {
-        randomizeObjective({currentTarget: document.getElementById("objectiveRandom")}, false);
     }
+    $("#objectiveMultiSelect").val(objective_multi).trigger("chosen:updated");
 
     $("#objectiveMultiSelect").on('change', objective_change);
 }

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -665,17 +665,32 @@ function setMaxObjective(isRandom) {
     }
 }
 
-var objectiveBackup = ["kill all G4"];
+var objectiveBackup = {
+    true: {{ response.write("{}".format(session.randomizer.get('objectiveMultiSelect',[])), escape=False) }},
+    false: {{ response.write("{}".format(session.randomizer.get('objective', [])), escape=False) }},
+}
+
 function randomizeObjective(evt, takeBackup=true) {
     var isActive;
-    if(isElemRandom(evt.currentTarget)) {
+    var wasRandom = isElemRandom(evt.currentTarget)
+
+    // backup current value
+    if (takeBackup) {
+        objectiveBackup[wasRandom] = get_selected_objectives()
+    }
+
+    if(wasRandom) {
         evt.currentTarget.className = evt.currentTarget.className.replace(" active", "");
         isActive = false;
 
         setMaxObjective(false);
 
         // restore previous value
-        $("#objectiveMultiSelect").val(objectiveBackup).trigger("chosen:updated");
+        var backup_values = objectiveBackup.false
+        if (backup_values.length === 0) {
+            backup_values = ['kill all g4']
+        }
+        $("#objectiveMultiSelect").val(backup_values).trigger("chosen:updated");
         removed_objectives = [];
 
         // handle exclusions for currently selected values
@@ -686,40 +701,39 @@ function randomizeObjective(evt, takeBackup=true) {
     } else {
         evt.currentTarget.className += " active";
         isActive = true;
-
-        // backup current value
-        if(takeBackup) {
-            objectiveBackup = get_selected_objectives();
-        }
-
         setMaxObjective(true);
-
-        // add all objectives for randomization, as we may have removed some of them from the dropdown list
-        var notSelectedArray = get_unselected_objectives();
-        var selectedArray = get_selected_objectives();
-
-        for(var i=0; i<defaultMultiValues["objective"].length; i++) {
-            var toAdd = defaultMultiValues["objective"][i];
-            // don't add 'collect 100% items' to the random list as it's a special objective
-            if(toAdd == "collect 100% items") {
-                continue;
-            }
-            if(!notSelectedArray.includes(toAdd) && !selectedArray.includes(toAdd)) {
-                $("#objectiveMultiSelect").append("<option value=\""+toAdd+"\">"+toAdd+"</option>");
-            }
+        var backup_values = objectiveBackup.true
+        if (backup_values.length === 0) {
+            backup_values = getAllObjectives()
         }
-        var all_objectives = Array.from(defaultMultiValues["objective"]);
-        var index = all_objectives.indexOf("collect 100% items");
-        if(index > -1) {
-            all_objectives.splice(index, 1);
-        }
-
-        $("#objectiveMultiSelect").val(all_objectives);
+        $("#objectiveMultiSelect").val(backup_values).trigger("chosen:updated");
     }
 
     sort_objectives_and_add_optgroups();
 
     disableElement("objective", isActive);
+}
+
+function getAllObjectives() {
+    // add all objectives for randomization, as we may have removed some of them from the dropdown list
+    var notSelectedArray = get_unselected_objectives();
+    var selectedArray = get_selected_objectives();
+    for(var i=0; i<defaultMultiValues["objective"].length; i++) {
+        var toAdd = defaultMultiValues["objective"][i];
+        // don't add 'collect 100% items' to the random list as it's a special objective
+        if(toAdd == "collect 100% items") {
+            continue;
+        }
+        if(!notSelectedArray.includes(toAdd) && !selectedArray.includes(toAdd)) {
+            $("#objectiveMultiSelect").append("<option value=\""+toAdd+"\">"+toAdd+"</option>");
+        }
+    }
+    var all_objectives = Array.from(defaultMultiValues["objective"]);
+    var index = all_objectives.indexOf("collect 100% items");
+    if(index > -1) {
+        all_objectives.splice(index, 1);
+    }
+    return all_objectives
 }
 
 function disableElement(id, disable) {
@@ -1089,41 +1103,34 @@ function AjaxRandomizerCallCompleted(data) {
 }
 
 function getSpecialValues(dataDict) {
-    // special case for objectives multiselect
-    if(isElemIdRandom("objective")) {
-      // Number of objectives can be controlled when objectives is random
-      if (!isElemIdRandom("nbObjective")) {
-        dataDict.objective = document.getElementById("nbObjective").value
-      } else {
-        dataDict["objective"] = "random";
-        dataDict["objectiveMultiSelect"] = $("#objectiveMultiSelect").val().join();
-      }
+    dataDict["objectiveRandom"] = isElemIdRandom("objective")
+
+    // Note both objective and objectiveMultiSelect are passed via dataDict.objective
+    // The backend decides to use this for one or the other
+    var values = $("#objectiveMultiSelect").val().join(",");
+    dataDict["objective"] = values ? values : "nothing"
+
+    if (isElemIdRandom("nbObjective")) {
+        dataDict["nbObjective"] = "random"
     } else {
-        var objectives = get_selected_objectives();
-        if(objectives.length == 0) {
-            dataDict["objective"] = "nothing";
-        } else {
-            dataDict["objective"] = objectives.join();
-        }
+        dataDict["nbObjective"] = document.getElementById("nbObjective").value
     }
 }
 
 function validateObjectives() {
     //var objectives = document.getElementById("objectiveMultiSelect");
     //console.log("objectiveMultiSelect: "+objectives.value);
-    var objectives = $("#objectiveMultiSelect");
-    var nbObjectives = objectives.val().length;
-    console.log("objectiveMultiSelect: "+objectives.val().join());
+    var values = $("#objectiveMultiSelect").val();
 
     if(isElemIdRandom("objective")) {
         // if objectives are randomized, check that there's at least one in the list
-        if(nbObjectives == 0) {
+        if(values.length == 0) {
             alert("Objectives are randomized but objectives list is empty");
             return false;
         }
     } else {
         // if not randomized, check that there's max 5 objectives in the list (4 in scav hunt)
-        if(nbObjectives > max_objectives) {
+        if(values.length > max_objectives) {
             alert("You can have maximum five objectives (four if major split is Scavenger Hunt)");
             return false
         }
@@ -1683,7 +1690,7 @@ function loadRandoPresetOK(data) {
 
     // objectives is special
     var objectiveRandom = document.getElementById("objectiveRandom");
-    if(data["objective"] == "random") {
+    if(data["objectiveRandom"] == "true") {
         if(! isElemRandom(objectiveRandom)) {
             randomizeObjective({currentTarget: objectiveRandom});
         }
@@ -2512,6 +2519,14 @@ def displaySelect(id, values, default):
 
 {{
 def displayMultiSelect(id, selectedValues, default, multipleValues):
+  # values for objective are stored differently
+  if id == "objective":
+    if session.randomizer.get("objectiveRandom"):
+      selectedValues = session.randomizer["objectiveMultiSelect"]
+    else:
+      selectedValues = session.randomizer["objective"] or ["kill all g4"]
+      pass
+    pass
   displaySelect(id, multipleValues, default)
 
   response.write("<div id=\"{}MultiSelectDiv\" style=\"display:none\">".format(id), escape=False)
@@ -2533,6 +2548,9 @@ def displayMultiSelect(id, selectedValues, default, multipleValues):
 def displayNumber(id, min, max, default, step="1"):
   if id in session.randomizer:
     value = session.randomizer[id]
+    if value == 'random' and id == 'nbObjective':
+      value = 0
+      pass
   else:
     value = default
     pass
@@ -2651,13 +2669,13 @@ def displayNumber(id, min, max, default, step="1"):
               <tr>
                 <td class="small"><div class="random"><button id="objectiveRandom" type="button" onclick="randomizeObjective(event)" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="objectiveText">Objectives to access Tourian:</span></td>
-                <td>{{displayMultiSelect("objective", currentMultiValues["objective"], "", defaultMultiValues["objective"])}}</td>
+                <td>{{displayMultiSelect("objective", "objective is special!", "", defaultMultiValues["objective"])}}</td>
                 <td id="objectiveStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
               <tr id="nbObjectiveVisiblity">
                 <td class="small"><div class="random"><button id="nbObjectiveRandom" type="button" onclick="randomize(event, 'nbObjective')" class="small"><span class="small dice_rotate">&#x2684;</span></button></div></td>
                 <td><span id="nbObjectiveText">Number of objectives:</span></td>
-                <td>{{displayNumber("nbObjective", "1", "5", "4", "1")}}</td>
+                <td>{{displayNumber("nbObjective", "0", "5", "4", "1")}}</td>
                 <td id="nbObjectiveStep"><button type="button" onclick="startTheTour(event)">?</button></td>
               </tr>
             </table>


### PR DESCRIPTION
## Instructions

* The second commit (ca408ed8) changed startTheTour to work with event and elementId. With event it searches for the parent or parents previous sibling with an Id and uses that as elementId. With elmentId (any string) it searches the steps to find the tour spot corresponding to that event. This will prevent us from needing to renumber everything next time we add a new tour element. I left this in a separate commit so it can be removed if someone has objections.
* Selecting 1 "tourian objective" will hide the number of objectives. Selecting more than one will show it.
* Clicking the dice disables nbObjective and sends "random" as the value.