### PR TITLE
Randomize + Customize no longer downloads and applies IPS

### DIFF
--- a/web/backend/randomizer.py
+++ b/web/backend/randomizer.py
@@ -300,6 +300,9 @@ class Randomizer(object):
             if self.storeLocalIps(guid, locsItems["fileName"], locsItems["ips"]):
                 db.addRandoUploadResult(id, guid, locsItems["fileName"])
                 locsItems['seedKey'] = guid
+                if self.vars.get('wantsCustomize') == 'true':
+                    # don't send the ips if they requested a redirect to the customize page
+                    locsItems.pop('ips')
             db.close()
 
             os.close(fd1)

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -1051,7 +1051,11 @@ function AjaxRandomizerCallCompleted(data) {
         var link = encodeURI(host+"/customizer/"+seedKey);
         document.getElementById("permalink").innerHTML = "<a href=\""+link+"\" target=\"_blank\">"+link+"</a>";
         if (wantsCustomize) {
-            window.location = link
+            var target = link
+            if (data['errorMsg']) {
+                 target += `?msg=${data['errorMsg']}`
+            }
+            window.location = target
         }
     }
 

--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -899,6 +899,8 @@ function AjaxPresetCallCompleted(data) {
         url = window.location.protocol+"//"+prodUrls[Math.floor(Math.random() * 2)]+"/randomizerWebService";
     }
 
+    dataDict.wantsCustomize = wantsCustomize
+
     // call web service with parameters
     var request = $.ajax({
       url: url,
@@ -948,28 +950,7 @@ function unpack_2bytes(ips, i) {
   return (b1*256) + b2;
 }
 
-function AjaxRandomizerCallCompleted(data) {
-    console.log("AjaxRandomizerCallCompleted");
-
-    $('#overlay').hide();
-    $('#loadingGIF').hide();
-
-    // info message to display ?
-    if("errorMsg" in data && data["errorMsg"].length > 0) {
-        document.getElementById("flash").innerHTML = data["errorMsg"];
-        $('#flash').show();
-    }
-
-    if("status" in data) {
-        var status = data["status"];
-        if(status != "OK") {
-            return;
-        }
-    } else {
-        document.getElementById("flash").innerHTML = "Something wrong happened or the VARIA randomizer aborted: please try again.";
-        return;
-    }
-
+function applyIpsAndDownload(data) {
     // with items/Locations patch the local rom in memory
     // always make a copy to avoid modifying vanilla rom buffer from local storage
     var bytes_temp = new Uint8Array(vanillaROM);
@@ -1031,6 +1012,34 @@ function AjaxRandomizerCallCompleted(data) {
 
     var outFileName = data['fileName'];
     saveAs(blob, outFileName);
+}
+
+function AjaxRandomizerCallCompleted(data) {
+    console.log("AjaxRandomizerCallCompleted");
+
+    $('#overlay').hide();
+    $('#loadingGIF').hide();
+
+    // info message to display ?
+    if("errorMsg" in data && data["errorMsg"].length > 0) {
+        document.getElementById("flash").innerHTML = data["errorMsg"];
+        $('#flash').show();
+    }
+
+    if("status" in data) {
+        var status = data["status"];
+        if(status != "OK") {
+            return;
+        }
+    } else {
+        document.getElementById("flash").innerHTML = "Something wrong happened or the VARIA randomizer aborted: please try again.";
+        return;
+    }
+
+    if (data["ips"]) {
+        // If data is missing ips it is most likely because they hit "Randomize + Customize"
+        applyIpsAndDownload(data);
+    }
 
     // add permalink
     if('seedKey' in data) {


### PR DESCRIPTION
The way the diff is represented is a little confusing. Basically I:
* Pulled all the code involving applying the IPS and moved it into a new function `applyIpsAndDownload` (unfortunately because that was a longer passage than the first few lines of `AjaxRandomizerCallComplete`, it looks like I moved those lines instead)
* Only call that function if data['ips'] is true
* Remove data['ips'] on the backend if the frontend sent `wantsCustomize=true`