### PR TITLE
zooming no longer screws with height tiny elements

### DIFF
--- a/web/views/t_main.html
+++ b/web/views/t_main.html
@@ -740,177 +740,173 @@
       <div id="Energy_pause" class="Energy_pause">
         <img src="/solver/static/images/tracker/inventory/energy.png" class="full">
       </div>
-      <div id="Energy_90_pause" class="Energy_90_pause">
+      <div id="Energy_90_pause" class="Energy_90_pause ammo_text">
         <img src="/solver/static/images/tracker/inventory/9.png" class="full">
       </div>
-      <div id="Energy_9_pause" class="Energy_9_pause">
+      <div id="Energy_9_pause" class="Energy_9_pause ammo_text">
         <img src="/solver/static/images/tracker/inventory/9.png" class="full">
       </div>
 
-      <div id="ETank_1_pause" class="ETank_1_pause">
+      <div id="ETank_1_pause" class="ETank_1_pause energy_row_1">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_2_pause" class="ETank_2_pause">
+      <div id="ETank_2_pause" class="ETank_2_pause energy_row_1">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_3_pause" class="ETank_3_pause">
+      <div id="ETank_3_pause" class="ETank_3_pause energy_row_1">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_4_pause" class="ETank_4_pause">
+      <div id="ETank_4_pause" class="ETank_4_pause energy_row_1">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_5_pause" class="ETank_5_pause">
+      <div id="ETank_5_pause" class="ETank_5_pause energy_row_1">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_6_pause" class="ETank_6_pause">
+      <div id="ETank_6_pause" class="ETank_6_pause energy_row_1">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_7_pause" class="ETank_7_pause">
+      <div id="ETank_7_pause" class="ETank_7_pause energy_row_1">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_8_pause" class="ETank_8_pause">
+      <div id="ETank_8_pause" class="ETank_8_pause energy_row_2">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_9_pause" class="ETank_9_pause">
+      <div id="ETank_9_pause" class="ETank_9_pause energy_row_2">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_10_pause" class="ETank_10_pause">
+      <div id="ETank_10_pause" class="ETank_10_pause energy_row_2">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_11_pause" class="ETank_11_pause">
+      <div id="ETank_11_pause" class="ETank_11_pause energy_row_2">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_12_pause" class="ETank_12_pause">
+      <div id="ETank_12_pause" class="ETank_12_pause energy_row_2">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_13_pause" class="ETank_13_pause">
+      <div id="ETank_13_pause" class="ETank_13_pause energy_row_2">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
-      <div id="ETank_14_pause" class="ETank_14_pause">
+      <div id="ETank_14_pause" class="ETank_14_pause energy_row_2">
         <img src="/solver/static/images/tracker/inventory/ietank.png" class="full">
       </div>
 
       <div id="Reserve_pause_increase" class="Reserve_pause_increase" onclick="actionItem('Reserve', 'add')" title="Add one Reserve Tank"></div>
       <div id="Reserve_pause_decrease" class="Reserve_pause_decrease" onclick="actionItem('Reserve', 'remove')" title="Remove one Reserve Tank"></div>
-      <div id="Reserve_1_pause" class="Reserve_1_pause">
+      <div id="Reserve_1_pause" class="Reserve_1_pause reserve_tank">
         <img src="/solver/static/images/tracker/inventory/ireserve.png" class="full">
       </div>
-      <div id="Reserve_2_pause" class="Reserve_2_pause">
+      <div id="Reserve_2_pause" class="Reserve_2_pause reserve_tank">
         <img src="/solver/static/images/tracker/inventory/ireserve.png" class="full">
       </div>
-      <div id="Reserve_3_pause" class="Reserve_3_pause">
+      <div id="Reserve_3_pause" class="Reserve_3_pause reserve_tank">
         <img src="/solver/static/images/tracker/inventory/ireserve.png" class="full">
       </div>
-      <div id="Reserve_4_pause" class="Reserve_4_pause">
+      <div id="Reserve_4_pause" class="Reserve_4_pause reserve_tank">
         <img src="/solver/static/images/tracker/inventory/ireserve.png" class="full">
       </div>
 
-      <div id="Missile_900_0_pause" class="Missile_900_0_pause">
-        <img src="/solver/static/images/tracker/inventory/0.png" class="full">
-      </div>
+      <div id="Missile_900_0_pause" class="Missile_900_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="Missile_900_1_pause" class="Missile_900_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="Missile_900_2_pause" class="Missile_900_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="Missile_900_3_pause" class="Missile_900_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="Missile_900_4_pause" class="Missile_900_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="Missile_900_5_pause" class="Missile_900_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="Missile_900_6_pause" class="Missile_900_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="Missile_900_7_pause" class="Missile_900_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="Missile_900_8_pause" class="Missile_900_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="Missile_900_9_pause" class="Missile_900_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
+      <div id="Missile_90_0_pause" class="Missile_90_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="Missile_90_1_pause" class="Missile_90_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="Missile_90_2_pause" class="Missile_90_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="Missile_90_3_pause" class="Missile_90_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="Missile_90_4_pause" class="Missile_90_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="Missile_90_5_pause" class="Missile_90_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="Missile_90_6_pause" class="Missile_90_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="Missile_90_7_pause" class="Missile_90_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="Missile_90_8_pause" class="Missile_90_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="Missile_90_9_pause" class="Missile_90_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
+      <div id="Missile_9_0_pause" class="Missile_9_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="Missile_9_1_pause" class="Missile_9_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="Missile_9_2_pause" class="Missile_9_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="Missile_9_3_pause" class="Missile_9_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="Missile_9_4_pause" class="Missile_9_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="Missile_9_5_pause" class="Missile_9_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="Missile_9_6_pause" class="Missile_9_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="Missile_9_7_pause" class="Missile_9_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="Missile_9_8_pause" class="Missile_9_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="Missile_9_9_pause" class="Missile_9_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
 
-      <div id="Missile_900_0_pause" class="Missile_900_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="Missile_900_1_pause" class="Missile_900_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="Missile_900_2_pause" class="Missile_900_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="Missile_900_3_pause" class="Missile_900_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="Missile_900_4_pause" class="Missile_900_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="Missile_900_5_pause" class="Missile_900_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="Missile_900_6_pause" class="Missile_900_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="Missile_900_7_pause" class="Missile_900_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="Missile_900_8_pause" class="Missile_900_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="Missile_900_9_pause" class="Missile_900_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
-      <div id="Missile_90_0_pause" class="Missile_90_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="Missile_90_1_pause" class="Missile_90_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="Missile_90_2_pause" class="Missile_90_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="Missile_90_3_pause" class="Missile_90_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="Missile_90_4_pause" class="Missile_90_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="Missile_90_5_pause" class="Missile_90_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="Missile_90_6_pause" class="Missile_90_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="Missile_90_7_pause" class="Missile_90_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="Missile_90_8_pause" class="Missile_90_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="Missile_90_9_pause" class="Missile_90_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
-      <div id="Missile_9_0_pause" class="Missile_9_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="Missile_9_1_pause" class="Missile_9_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="Missile_9_2_pause" class="Missile_9_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="Missile_9_3_pause" class="Missile_9_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="Missile_9_4_pause" class="Missile_9_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="Missile_9_5_pause" class="Missile_9_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="Missile_9_6_pause" class="Missile_9_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="Missile_9_7_pause" class="Missile_9_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="Missile_9_8_pause" class="Missile_9_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="Missile_9_9_pause" class="Missile_9_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
+      <div id="Super_900_0_pause" class="Super_900_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="Super_900_1_pause" class="Super_900_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="Super_900_2_pause" class="Super_900_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="Super_900_3_pause" class="Super_900_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="Super_900_4_pause" class="Super_900_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="Super_900_5_pause" class="Super_900_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="Super_900_6_pause" class="Super_900_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="Super_900_7_pause" class="Super_900_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="Super_900_8_pause" class="Super_900_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="Super_900_9_pause" class="Super_900_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
+      <div id="Super_90_0_pause" class="Super_90_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="Super_90_1_pause" class="Super_90_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="Super_90_2_pause" class="Super_90_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="Super_90_3_pause" class="Super_90_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="Super_90_4_pause" class="Super_90_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="Super_90_5_pause" class="Super_90_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="Super_90_6_pause" class="Super_90_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="Super_90_7_pause" class="Super_90_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="Super_90_8_pause" class="Super_90_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="Super_90_9_pause" class="Super_90_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
+      <div id="Super_9_0_pause" class="Super_9_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="Super_9_1_pause" class="Super_9_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="Super_9_2_pause" class="Super_9_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="Super_9_3_pause" class="Super_9_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="Super_9_4_pause" class="Super_9_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="Super_9_5_pause" class="Super_9_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="Super_9_6_pause" class="Super_9_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="Super_9_7_pause" class="Super_9_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="Super_9_8_pause" class="Super_9_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="Super_9_9_pause" class="Super_9_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
 
-      <div id="Super_900_0_pause" class="Super_900_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="Super_900_1_pause" class="Super_900_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="Super_900_2_pause" class="Super_900_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="Super_900_3_pause" class="Super_900_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="Super_900_4_pause" class="Super_900_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="Super_900_5_pause" class="Super_900_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="Super_900_6_pause" class="Super_900_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="Super_900_7_pause" class="Super_900_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="Super_900_8_pause" class="Super_900_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="Super_900_9_pause" class="Super_900_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
-      <div id="Super_90_0_pause" class="Super_90_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="Super_90_1_pause" class="Super_90_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="Super_90_2_pause" class="Super_90_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="Super_90_3_pause" class="Super_90_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="Super_90_4_pause" class="Super_90_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="Super_90_5_pause" class="Super_90_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="Super_90_6_pause" class="Super_90_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="Super_90_7_pause" class="Super_90_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="Super_90_8_pause" class="Super_90_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="Super_90_9_pause" class="Super_90_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
-      <div id="Super_9_0_pause" class="Super_9_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="Super_9_1_pause" class="Super_9_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="Super_9_2_pause" class="Super_9_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="Super_9_3_pause" class="Super_9_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="Super_9_4_pause" class="Super_9_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="Super_9_5_pause" class="Super_9_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="Super_9_6_pause" class="Super_9_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="Super_9_7_pause" class="Super_9_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="Super_9_8_pause" class="Super_9_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="Super_9_9_pause" class="Super_9_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
-
-      <div id="PowerBomb_900_0_pause" class="PowerBomb_900_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="PowerBomb_900_1_pause" class="PowerBomb_900_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="PowerBomb_900_2_pause" class="PowerBomb_900_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="PowerBomb_900_3_pause" class="PowerBomb_900_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="PowerBomb_900_4_pause" class="PowerBomb_900_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="PowerBomb_900_5_pause" class="PowerBomb_900_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="PowerBomb_900_6_pause" class="PowerBomb_900_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="PowerBomb_900_7_pause" class="PowerBomb_900_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="PowerBomb_900_8_pause" class="PowerBomb_900_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="PowerBomb_900_9_pause" class="PowerBomb_900_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
-      <div id="PowerBomb_90_0_pause" class="PowerBomb_90_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="PowerBomb_90_1_pause" class="PowerBomb_90_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="PowerBomb_90_2_pause" class="PowerBomb_90_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="PowerBomb_90_3_pause" class="PowerBomb_90_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="PowerBomb_90_4_pause" class="PowerBomb_90_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="PowerBomb_90_5_pause" class="PowerBomb_90_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="PowerBomb_90_6_pause" class="PowerBomb_90_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="PowerBomb_90_7_pause" class="PowerBomb_90_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="PowerBomb_90_8_pause" class="PowerBomb_90_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="PowerBomb_90_9_pause" class="PowerBomb_90_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
-      <div id="PowerBomb_9_0_pause" class="PowerBomb_9_0_pause"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
-      <div id="PowerBomb_9_1_pause" class="PowerBomb_9_1_pause"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
-      <div id="PowerBomb_9_2_pause" class="PowerBomb_9_2_pause"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
-      <div id="PowerBomb_9_3_pause" class="PowerBomb_9_3_pause"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
-      <div id="PowerBomb_9_4_pause" class="PowerBomb_9_4_pause"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
-      <div id="PowerBomb_9_5_pause" class="PowerBomb_9_5_pause"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
-      <div id="PowerBomb_9_6_pause" class="PowerBomb_9_6_pause"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
-      <div id="PowerBomb_9_7_pause" class="PowerBomb_9_7_pause"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
-      <div id="PowerBomb_9_8_pause" class="PowerBomb_9_8_pause"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
-      <div id="PowerBomb_9_9_pause" class="PowerBomb_9_9_pause"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
+      <div id="PowerBomb_900_0_pause" class="PowerBomb_900_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="PowerBomb_900_1_pause" class="PowerBomb_900_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="PowerBomb_900_2_pause" class="PowerBomb_900_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="PowerBomb_900_3_pause" class="PowerBomb_900_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="PowerBomb_900_4_pause" class="PowerBomb_900_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="PowerBomb_900_5_pause" class="PowerBomb_900_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="PowerBomb_900_6_pause" class="PowerBomb_900_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="PowerBomb_900_7_pause" class="PowerBomb_900_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="PowerBomb_900_8_pause" class="PowerBomb_900_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="PowerBomb_900_9_pause" class="PowerBomb_900_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
+      <div id="PowerBomb_90_0_pause" class="PowerBomb_90_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="PowerBomb_90_1_pause" class="PowerBomb_90_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="PowerBomb_90_2_pause" class="PowerBomb_90_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="PowerBomb_90_3_pause" class="PowerBomb_90_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="PowerBomb_90_4_pause" class="PowerBomb_90_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="PowerBomb_90_5_pause" class="PowerBomb_90_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="PowerBomb_90_6_pause" class="PowerBomb_90_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="PowerBomb_90_7_pause" class="PowerBomb_90_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="PowerBomb_90_8_pause" class="PowerBomb_90_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="PowerBomb_90_9_pause" class="PowerBomb_90_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
+      <div id="PowerBomb_9_0_pause" class="PowerBomb_9_0_pause ammo_text"><img src="/solver/static/images/tracker/inventory/0.png" class="full"></div>
+      <div id="PowerBomb_9_1_pause" class="PowerBomb_9_1_pause ammo_text"><img src="/solver/static/images/tracker/inventory/1.png" class="full"></div>
+      <div id="PowerBomb_9_2_pause" class="PowerBomb_9_2_pause ammo_text"><img src="/solver/static/images/tracker/inventory/2.png" class="full"></div>
+      <div id="PowerBomb_9_3_pause" class="PowerBomb_9_3_pause ammo_text"><img src="/solver/static/images/tracker/inventory/3.png" class="full"></div>
+      <div id="PowerBomb_9_4_pause" class="PowerBomb_9_4_pause ammo_text"><img src="/solver/static/images/tracker/inventory/4.png" class="full"></div>
+      <div id="PowerBomb_9_5_pause" class="PowerBomb_9_5_pause ammo_text"><img src="/solver/static/images/tracker/inventory/5.png" class="full"></div>
+      <div id="PowerBomb_9_6_pause" class="PowerBomb_9_6_pause ammo_text"><img src="/solver/static/images/tracker/inventory/6.png" class="full"></div>
+      <div id="PowerBomb_9_7_pause" class="PowerBomb_9_7_pause ammo_text"><img src="/solver/static/images/tracker/inventory/7.png" class="full"></div>
+      <div id="PowerBomb_9_8_pause" class="PowerBomb_9_8_pause ammo_text"><img src="/solver/static/images/tracker/inventory/8.png" class="full"></div>
+      <div id="PowerBomb_9_9_pause" class="PowerBomb_9_9_pause ammo_text"><img src="/solver/static/images/tracker/inventory/9.png" class="full"></div>
 
       <div id="auto" class="auto"><img src="/solver/static/images/tracker/inventory/auto.png" class="full"></div>
       <div id="reserve_text" class="reserve_text"><img src="/solver/static/images/tracker/inventory/reserve_text.png" class="full"></div>
 
-      <div id="reserve_0" class="reserve_0"><img src="/solver/static/images/tracker/inventory/0_reserve.png" class="full"></div>
-      <div id="reserve_00" class="reserve_00"><img src="/solver/static/images/tracker/inventory/0_reserve.png" class="full"></div>
-      <div id="reserve_1" class="reserve_1"><img src="/solver/static/images/tracker/inventory/1_reserve.png" class="full"></div>
-      <div id="reserve_2" class="reserve_1"><img src="/solver/static/images/tracker/inventory/2_reserve.png" class="full"></div>
-      <div id="reserve_3" class="reserve_1"><img src="/solver/static/images/tracker/inventory/3_reserve.png" class="full"></div>
-      <div id="reserve_4" class="reserve_1"><img src="/solver/static/images/tracker/inventory/4_reserve.png" class="full"></div>
+      <div id="reserve_0" class="reserve_0 reserve_number"><img src="/solver/static/images/tracker/inventory/0_reserve.png" class="full"></div>
+      <div id="reserve_00" class="reserve_00 reserve_number"><img src="/solver/static/images/tracker/inventory/0_reserve.png" class="full"></div>
+      <div id="reserve_1" class="reserve_1 reserve_number"><img src="/solver/static/images/tracker/inventory/1_reserve.png" class="full"></div>
+      <div id="reserve_2" class="reserve_1 reserve_number"><img src="/solver/static/images/tracker/inventory/2_reserve.png" class="full"></div>
+      <div id="reserve_3" class="reserve_1 reserve_number"><img src="/solver/static/images/tracker/inventory/3_reserve.png" class="full"></div>
+      <div id="reserve_4" class="reserve_1 reserve_number"><img src="/solver/static/images/tracker/inventory/4_reserve.png" class="full"></div>
     </div>
 
     <input id="timer" type="time" value="03:00" class="timer" style="display:none">

--- a/web/views/t_style.html
+++ b/web/views/t_style.html
@@ -186,6 +186,7 @@ img {
     font-weight: bold;
 }
 .repeatArea {
+    line-height: 0;
     cursor: pointer;
     position: absolute;
     z-index: 2;
@@ -195,6 +196,7 @@ img {
     left: 13.25%;
 }
 .binArea {
+    line-height: 0;
     cursor: pointer;
     position: absolute;
     z-index: 2;
@@ -2484,6 +2486,7 @@ img {
     height: 2.2%;
 }
 .Missile_pause {
+    line-height: 0;
     position: absolute;
     display: none;
     z-index: 1;
@@ -2510,6 +2513,7 @@ img {
     height: 2.2%;
 }
 .Super_pause {
+    line-height: 0;
     position: absolute;
     display: none;
     z-index: 1;
@@ -2536,6 +2540,7 @@ img {
     height: 2.2%;
 }
 .PowerBomb_pause {
+    line-height: 0;
     position: absolute;
     display: none;
     z-index: 1;
@@ -3395,6 +3400,7 @@ img {
     height: 1.1%;
 }
 .auto {
+    line-height: 0;
     position: absolute;
     z-index: 1;
     left: 5%;
@@ -3403,6 +3409,7 @@ img {
     display: none;
 }
 .reserve_text {
+    line-height: 0;
     position: absolute;
     z-index: 1;
     left: 1.7%;

--- a/web/views/t_style.html
+++ b/web/views/t_style.html
@@ -1,4 +1,7 @@
 {{include 'solver_web/varia.css'}}
+.lh-fix {
+    line-height: 0;
+}
 .objectivesPopup {
     position: absolute;
     top: 0%;
@@ -2577,11 +2580,20 @@ img {
     height: 1.1%;
 }
 .Energy_pause {
+    line-height: 0;
     position: absolute;
     z-index: 1;
     left: 0.6%;
-    top: 12.4%;
+    top: 13.075%;
     width: 2.35%;
+}
+.energy_row_1 {
+    line-height: 0;
+    top: 11.85%;
+}
+.energy_row_2 {
+    line-height: 0;
+    top: 10.525%;
 }
 .Energy_90_pause {
     position: absolute;
@@ -2602,7 +2614,6 @@ img {
     display: none;
     z-index: 1;
     left: 0.6%;
-    top: 11%;
     width: 0.44%;
 }
 .ETank_2_pause {
@@ -2610,7 +2621,6 @@ img {
     display: none;
     z-index: 1;
     left: 1.2%;
-    top: 11%;
     width: 0.44%;
 }
 .ETank_3_pause {
@@ -2618,7 +2628,6 @@ img {
     display: none;
     z-index: 1;
     left: 1.8%;
-    top: 11%;
     width: 0.44%;
 }
 .ETank_4_pause {
@@ -2626,7 +2635,6 @@ img {
     display: none;
     z-index: 1;
     left: 2.4%;
-    top: 11%;
     width: 0.44%;
 }
 .ETank_5_pause {
@@ -2634,7 +2642,6 @@ img {
     display: none;
     z-index: 1;
     left: 3%;
-    top: 11%;
     width: 0.44%;
 }
 .ETank_6_pause {
@@ -2642,7 +2649,6 @@ img {
     display: none;
     z-index: 1;
     left: 3.6%;
-    top: 11%;
     width: 0.44%;
 }
 .ETank_7_pause {
@@ -2650,7 +2656,6 @@ img {
     display: none;
     z-index: 1;
     left: 4.2%;
-    top: 11%;
     width: 0.44%;
 }
 .ETank_8_pause {
@@ -2658,7 +2663,6 @@ img {
     display: none;
     z-index: 1;
     left: 0.6%;
-    top: 9.7%;
     width: 0.44%;
 }
 .ETank_9_pause {
@@ -2666,7 +2670,6 @@ img {
     display: none;
     z-index: 1;
     left: 1.2%;
-    top: 9.7%;
     width: 0.44%;
 }
 .ETank_10_pause {
@@ -2674,7 +2677,6 @@ img {
     display: none;
     z-index: 1;
     left: 1.8%;
-    top: 9.7%;
     width: 0.44%;
 }
 .ETank_11_pause {
@@ -2682,7 +2684,6 @@ img {
     display: none;
     z-index: 1;
     left: 2.4%;
-    top: 9.7%;
     width: 0.44%;
 }
 .ETank_12_pause {
@@ -2690,7 +2691,6 @@ img {
     display: none;
     z-index: 1;
     left: 3%;
-    top: 9.7%;
     width: 0.44%;
 }
 .ETank_13_pause {
@@ -2698,7 +2698,6 @@ img {
     display: none;
     z-index: 1;
     left: 3.6%;
-    top: 9.7%;
     width: 0.44%;
 }
 .ETank_14_pause {
@@ -2706,15 +2705,17 @@ img {
     display: none;
     z-index: 1;
     left: 4.2%;
-    top: 9.7%;
     width: 0.44%;
+}
+.reserve_tank {
+    line-height: 0;
+    top: 23.9%;
 }
 .Reserve_1_pause {
     position: absolute;
     display: none;
     z-index: 1;
     left: 1.75%;
-    top: 23.1%;
     width: 0.66%;
 }
 .Reserve_2_pause {
@@ -2722,7 +2723,6 @@ img {
     display: none;
     z-index: 1;
     left: 2.35%;
-    top: 23.1%;
     width: 0.66%;
 }
 .Reserve_3_pause {
@@ -2730,7 +2730,6 @@ img {
     display: none;
     z-index: 1;
     left: 2.9%;
-    top: 23.1%;
     width: 0.66%;
 }
 .Reserve_4_pause {
@@ -2738,15 +2737,17 @@ img {
     display: none;
     z-index: 1;
     left: 3.5%;
-    top: 23.1%;
     width: 0.66%;
+}
+.ammo_text {
+    line-height: 0;
+    top: 13.1%;
 }
 .Missile_900_0_pause {
     position: absolute;
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_1_pause {
@@ -2754,7 +2755,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_2_pause {
@@ -2762,7 +2762,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_3_pause {
@@ -2770,7 +2769,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_4_pause {
@@ -2778,7 +2776,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_5_pause {
@@ -2786,7 +2783,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_6_pause {
@@ -2794,7 +2790,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_7_pause {
@@ -2802,7 +2797,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_8_pause {
@@ -2810,7 +2804,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_900_9_pause {
@@ -2818,7 +2811,6 @@ img {
     display: none;
     z-index: 1;
     left: 6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_0_pause {
@@ -2826,7 +2818,6 @@ img {
     display: none;
     z-index: 1;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_1_pause {
@@ -2834,7 +2825,6 @@ img {
     display: none;
     z-index: 1;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_2_pause {
@@ -2842,7 +2832,6 @@ img {
     display: none;
     z-index: 1;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_3_pause {
@@ -2850,7 +2839,6 @@ img {
     display: none;
     z-index: 1;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_4_pause {
@@ -2858,7 +2846,6 @@ img {
     display: none;
     z-index: 1;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_5_pause {
@@ -2866,7 +2853,6 @@ img {
     display: none;
     z-index: 1;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_6_pause {
@@ -2874,7 +2860,6 @@ img {
     display: none;
     z-index: 1;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_7_pause {
@@ -2882,7 +2867,6 @@ img {
     display: none;
     z-index: 1;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_8_pause {
@@ -2890,7 +2874,6 @@ img {
     z-index: 1;
     display: none;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_90_9_pause {
@@ -2898,7 +2881,6 @@ img {
     z-index: 1;
     display: none;
     left: 6.6%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_0_pause {
@@ -2906,7 +2888,6 @@ img {
     z-index: 1;
     display: none;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_1_pause {
@@ -2914,7 +2895,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_2_pause {
@@ -2922,7 +2902,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_3_pause {
@@ -2930,7 +2909,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_4_pause {
@@ -2938,7 +2916,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_5_pause {
@@ -2946,7 +2923,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_6_pause {
@@ -2954,7 +2930,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_7_pause {
@@ -2962,7 +2937,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_8_pause {
@@ -2970,7 +2944,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 .Missile_9_9_pause {
@@ -2978,7 +2951,6 @@ img {
     display: none;
     z-index: 1;
     left: 7.2%;
-    top: 12.5%;
     width: 0.5875%;
 }
 
@@ -2986,7 +2958,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -2994,7 +2965,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3002,7 +2972,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3010,7 +2979,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3018,7 +2986,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3026,7 +2993,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3034,7 +3000,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3042,7 +3007,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3050,7 +3014,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3058,7 +3021,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.05%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3066,7 +3028,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3074,7 +3035,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3082,7 +3042,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3090,7 +3049,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3098,7 +3056,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3106,7 +3063,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3114,7 +3070,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3122,7 +3077,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3130,7 +3084,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3138,7 +3091,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 8.6%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3146,7 +3098,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3154,7 +3105,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3162,7 +3112,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3170,7 +3119,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3178,7 +3126,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3186,7 +3133,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3194,7 +3140,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3202,7 +3147,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3210,7 +3154,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3218,7 +3161,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.15%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3227,7 +3169,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3235,7 +3176,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3243,7 +3183,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3251,7 +3190,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3259,7 +3197,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3267,7 +3204,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3275,7 +3211,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3283,7 +3218,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3291,7 +3225,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3299,7 +3232,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 9.9%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3307,7 +3239,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3315,7 +3246,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3323,7 +3253,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3331,7 +3260,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3339,7 +3267,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3347,7 +3274,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3355,7 +3281,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3363,7 +3288,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3371,7 +3295,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3379,7 +3302,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 10.45%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3387,7 +3309,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3395,7 +3316,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3403,7 +3323,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3411,7 +3330,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3419,7 +3337,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3427,7 +3344,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3435,7 +3351,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3443,7 +3358,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3451,7 +3365,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3459,7 +3372,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 11%;
-    top: 12.5%;
     width: 0.5875%;
     display: none;
 }
@@ -3503,7 +3415,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 5.9%;
-    top: 23.1%;
     width: 0.5875%;
     display: none;
 }
@@ -3511,15 +3422,17 @@ img {
     position: absolute;
     z-index: 1;
     left: 5.2%;
-    top: 23.1%;
     width: 0.5875%;
     display: none;
+}
+.reserve_number {
+    line-height: 0;
+    top: 23.7%;
 }
 .reserve_1 {
     position: absolute;
     z-index: 1;
     left: 4.55%;
-    top: 23.1%;
     width: 0.5875%;
     display: none;
 }
@@ -3527,7 +3440,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 4.55%;
-    top: 23.1%;
     width: 0.5875%;
     display: none;
 }
@@ -3535,7 +3447,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 4.55%;
-    top: 23.1%;
     width: 0.5875%;
     display: none;
 }
@@ -3543,7 +3454,6 @@ img {
     position: absolute;
     z-index: 1;
     left: 4.55%;
-    top: 23.1%;
     width: 0.5875%;
     display: none;
 }

--- a/web/views/tracker.html
+++ b/web/views/tracker.html
@@ -10,6 +10,7 @@
 {{include 'solver_web/t_style.html'}}
 
 .switchInventory {
+    line-height: 0;
     cursor: pointer;
     position: absolute;
     z-index: 2;
@@ -19,6 +20,7 @@
     left: 1.5%;
 }
 .switchMap {
+    line-height: 0;
     cursor: pointer;
     position: absolute;
     z-index: 2;
@@ -28,6 +30,7 @@
     left: 18.75%;
 }
 .help {
+    line-height: 0;
     cursor: pointer;
     position: absolute;
     z-index: 2;
@@ -37,6 +40,7 @@
     left: 2.75%;
 }
 .titleItem {
+    line-height: 0;
     position: absolute;
     z-index: 2;
     width: 10%;
@@ -48,6 +52,7 @@
     font-weight: bold;
 }
 .startItem {
+    line-height: 0;
     cursor: pointer;
     position: absolute;
     z-index: 2;
@@ -57,6 +62,7 @@
     left: 10.5%;
 }
 .repeatItem {
+    line-height: 0;
     cursor: pointer;
     position: absolute;
     z-index: 2;
@@ -66,6 +72,7 @@
     left: 13.25%;
 }
 .binItem {
+    line-height: 0;
     cursor: pointer;
     position: absolute;
     z-index: 2;


### PR DESCRIPTION
The reason this was a problem was that the images were less than 1 line height (20px). If an image is inline or inline-block then it will try to align itself with the text. If the image is smaller than 1 line height the parent container will be 1 line height and the image will be centered. When you zoom out the size of that 20px changes, but the percentage measurements don't. I fixed it by setting the line height to zero on every line that was affected and adjusting the top % accordingly.

I also took the initiative of generalizing the css a bit. I don't know if that was appropriate. I can undo that or do more of it in the future. I'd love to replace this with a javascript widget rather than several thousand lines of copy/pasted html and css.