### PR TITLE
Remove option to gate glitch without morph when leaving wave beam

### DIFF
--- a/graph/vanilla/graph_locations.py
+++ b/graph/vanilla/graph_locations.py
@@ -221,10 +221,9 @@ locationsDict["Wave Beam"].Available = (
 )
 locationsDict["Wave Beam"].PostAvailable = (
     lambda sm: sm.wor(sm.haveItem('Morph'), # exit through lower passage under the spikes
-                      sm.wand(sm.wor(sm.haveItem('SpaceJump'), # exit through blue gate
-                                     sm.haveItem('Grapple')),
-                              sm.wor(sm.wand(sm.canBlueGateGlitch(), sm.heatProof()), # hell run + green gate glitch is too much
-                                     sm.haveItem('Wave'))))
+                      sm.wand(sm.haveItem('Wave'), # exit through blue gate
+                              sm.wor(sm.haveItem('SpaceJump'),
+                                     sm.haveItem('Grapple'))))
 )
 locationsDict["Ridley"].AccessFrom = {
     'RidleyRoomIn': lambda sm: SMBool(True)


### PR DESCRIPTION
The randomizer can logically require a gate glitch leaving wave beam without morph, but with no way to farm for more ammo.  In fact, it appears the canBlueGateGlitch requirement only checks if you have missiles or supers, which means a single missile pack would put it in logic, but it would be impossible since the five missiles are required to open the wave beam door.

An alternative would be to have some sort of minimum ammo check, but not sure it is worth it.

FWIW I don't know how to test these changes myself.