### PR TITLE
fix slow sort function

### DIFF
--- a/web/views/plandorepo.html
+++ b/web/views/plandorepo.html
@@ -794,19 +794,19 @@ function dragElement(elmnt, headerId) {
 
 const sortTable = (id, n) => {
     const table = document.getElementById(id);
-    const rows = Array.from(table.querySelectorAll('.collapsible')).map((row) => ({
+    const rows = Array.from(table.querySelectorAll('.collapsible')).map((row, index) => ({
+        index,
         element: row,
         details: row.nextElementSibling,
-        value: row.getElementsByTagName("TD")[n].innerText.toLowerCase(),
+        value: row.getElementsByTagName("TD")[n].innerHTML.toLowerCase(),
     }))
 
+    rows.sort((a, b) => a.value.localeCompare(b.value, undefined, {numeric: true, sensitivity: 'base'}))
     let changed = false
-    rows.sort((a, b) => {
-        const v = b.value.localeCompare(a.value, undefined, {numeric: true, sensitivity: 'base'})
-        if (v === -1) {
+    rows.forEach((row, index) => {
+        if (index !== row.index) {
             changed = true
         }
-        return v
     })
     if (!changed) {
         // The table was already sorted, flip it upside down

--- a/web/views/plandorepo.html
+++ b/web/views/plandorepo.html
@@ -792,61 +792,31 @@ function dragElement(elmnt, headerId) {
   }
 }
 
-// https://www.w3schools.com/howto/howto_js_sort_table.asp
-function sortTable(id, n) {
-    var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
-    table = document.getElementById(id);
-    switching = true;
-    // Set the sorting direction to ascending:
-    dir = "asc";
-    /* Make a loop that will continue until
-       no switching has been done: */
-    while (switching) {
-        // Start by saying: no switching is done:
-        switching = false;
-        rows = table.rows;
-        /* Loop through all table rows (except the first, which contains table headers): */
-        // sort only one every two lines (as first line is summary and second line is long desc)
-        for (i = 1; i < rows.length - 3; i+=2) {
-            // Start by saying there should be no switching:
-            shouldSwitch = false;
-            /* Get the two elements you want to compare,
-               one from current row and one from the next: */
-            x = rows[i].getElementsByTagName("TD")[n];
-            y = rows[i + 2].getElementsByTagName("TD")[n];
-            /* Check if the two rows should switch place,
-               based on the direction, asc or desc: */
-            if (dir == "asc") {
-                if (x.innerHTML.toLowerCase().localeCompare(y.innerHTML.toLowerCase(), undefined, {numeric: true, sensitivity: 'base'}) > 0) {
-                    // If so, mark as a switch and break the loop:
-                    shouldSwitch = true;
-                    break;
-                }
-            } else if (dir == "desc") {
-                if (x.innerHTML.toLowerCase().localeCompare(y.innerHTML.toLowerCase(), undefined, {numeric: true, sensitivity: 'base'}) < 0) {
-                    // If so, mark as a switch and break the loop:
-                    shouldSwitch = true;
-                    break;
-                }
-            }
+const sortTable = (id, n) => {
+    const table = document.getElementById(id);
+    const rows = Array.from(table.querySelectorAll('.collapsible')).map((row) => ({
+        element: row,
+        details: row.nextElementSibling,
+        value: row.getElementsByTagName("TD")[n].innerText.toLowerCase(),
+    }))
+
+    let changed = false
+    rows.sort((a, b) => {
+        const v = b.value.localeCompare(a.value, undefined, {numeric: true, sensitivity: 'base'})
+        if (v === -1) {
+            changed = true
         }
-        if (shouldSwitch) {
-            /* If a switch has been marked, make the switch
-               and mark that a switch has been done: */
-            rows[i].parentNode.insertBefore(rows[i + 2], rows[i]);
-            rows[i].parentNode.insertBefore(rows[i + 3], rows[i+1]);
-            switching = true;
-            // Each time a switch is done, increase this count by 1:
-            switchcount ++;
-        } else {
-            /* If no switching has been done AND the direction is "asc",
-               set the direction to "desc" and run the while loop again. */
-            if (switchcount == 0 && dir == "asc") {
-                dir = "desc";
-                switching = true;
-            }
-        }
+        return v
+    })
+    if (!changed) {
+        // The table was already sorted, flip it upside down
+        rows.reverse()
     }
+    rows.forEach(row => {
+        // appendChild removes the node
+        table.appendChild(row.element)
+        table.appendChild(row.details)
+    })
 }
 
 function filter_plandos() {


### PR DESCRIPTION
Because the plando table had become large the old sort function was noticeably slow. The old sort function was sorting the nodes in place (so each row gets moved multiple times). The new function measures at ~70 ms (compared to 26000ms before). There is still a visual delay, but I think that's because the whole page is re-rendering. To improve on this we'll have to paginate the table.