### PR TITLE
Protect customizer re-seed settings

### DIFF
--- a/web/views/randomizer.html
+++ b/web/views/randomizer.html
@@ -729,7 +729,7 @@ var objectiveBackup = {
     true: {{ writeObjectiveList('objectiveMultiSelect') }},
     false: {{ writeObjectiveList('objective') }},
 }
-
+var appIsReady = false;
 var takeBackup = false;
 
 function randomizeObjective(evt) {
@@ -1698,6 +1698,7 @@ window.onload = function(){
             }
         }
     });
+    appIsReady = true;
 }
 
 function displayROMInput(show) {
@@ -1731,14 +1732,14 @@ function switchCheckbox(id, elems=[]) {
 }
 
 function setSwitchToOn(elem) {
-    if(! elem.checked) {
+    if(appIsReady && ! elem.checked) {
         elem.click();
         elem.value = "on";
     }
 }
 
 function setSwitchToOff(elem) {
-    if(elem.checked) {
+    if(appIsReady && elem.checked) {
         elem.click();
         elem.value = "off";
     }


### PR DESCRIPTION
Currently if you create a seed with area=light and escapeRando=off and "generate a new seed" via the customizer page, the front end will set escapeRando=on (as if you maneally selected area=light). This stops that by guarding setSwitchToOn/Off