### PR TITLE
Load inventory from game memory data for auto tracking - resolves #111

### DIFF
--- a/rom/romreader.py
+++ b/rom/romreader.py
@@ -302,7 +302,7 @@ class RomReader:
                 loc.itemName = self.items[item]["name"]
             except:
                 # race seeds
-                loc.itemName = "SpringBall"
+                loc.itemName = "NoEnergy"
                 item = '0x0'
 
         return (majorsSplit if majorsSplit != 'FullWithHUD' else 'Full', majorsSplit)

--- a/solver/commonSolver.py
+++ b/solver/commonSolver.py
@@ -284,11 +284,8 @@ class CommonSolver(object):
         # item
         item = loc.itemName
 
-        if self.mode in ['seedless', 'race', 'debug']:
-            # in seedless remove the first nothing found as collectedItems is not ordered
+        if item in self.collectedItems:
             self.collectedItems.remove(item)
-        else:
-            self.collectedItems.pop(locIndex)
 
         # if multiple majors in plando mode, remove it from smbm only when it's the last occurence of it
         if self.smbm.isCountItem(item):

--- a/solver/interactiveSolver.py
+++ b/solver/interactiveSolver.py
@@ -777,6 +777,30 @@ class InteractiveSolver(CommonSolver):
 
     eventsBitMasks = {}
 
+    inventoryBitMasks = {
+        'Varia': {"byteIndex": 0x0, "bitMask": 0x1},
+        'SpringBall': {"byteIndex": 0x0, "bitMask": 0x2},
+        'Morph': {"byteIndex": 0x0, "bitMask": 0x4},
+        'ScrewAttack': {"byteIndex": 0x0, "bitMask": 0x8},
+        'Gravity': {"byteIndex": 0x0, "bitMask": 0x20},
+        'HiJump': {"byteIndex": 0x1, "bitMask": 0x1},
+        'SpaceJump': {"byteIndex": 0x1, "bitMask": 0x2 },
+        'Bomb': {"byteIndex": 0x1, "bitMask": 0x10},
+        'SpeedBooster': {"byteIndex": 0x1, "bitMask": 0x20},
+        'Grapple': {"byteIndex": 0x1, "bitMask": 0x40},
+        'XRayScope': {"byteIndex": 0x1, "bitMask": 0x80},
+        'Wave': {"byteIndex": 0x4, "bitMask": 0x1},
+        'Ice': {"byteIndex": 0x4, "bitMask": 0x2},
+        'Spazer': {"byteIndex": 0x4, "bitMask": 0x4},
+        'Plasma': {"byteIndex": 0x4, "bitMask": 0x8},
+        'Charge': {"byteIndex": 0x5, "bitMask": 0x10},
+        'ETank': {"byteIndex": 0x6},
+        'Missile': {"byteIndex": 0xA},
+        'Super': {"byteIndex": 0xE},
+        'PowerBomb': {"byteIndex": 0x12},
+        'Reserve': {"byteIndex": 0x16},
+    }
+
     areaAccessPoints = {
         "Lower Mushrooms Left": {"byteIndex": 36, "bitMask": 1, "room": 0x9969, "area": "Crateria"},
         "Green Pirates Shaft Bottom Right": {"byteIndex": 37, "bitMask": 16, "room": 0x99bd, "area": "Crateria"},
@@ -1024,13 +1048,18 @@ class InteractiveSolver(CommonSolver):
             "samus": '4',
             "items": '5',
             "boss": '6',
-            "events": '7'
+            "events": '7',
+            "inventory": '8',
         }
 
         currentState = dumpData["currentState"]
         self.locDelta = 0
 
-        for dataType, offset in dumpData["stateDataOffsets"].items():
+        keys = list(dumpData["stateDataOffsets"].keys())
+        keys.sort()
+        for dataType in keys:
+            offset = dumpData["stateDataOffsets"][dataType]
+
             if dataType == dataEnum["items"]:
                 # get item data, loop on all locations to check if they have been visited
                 for loc in self.locations:
@@ -1063,6 +1092,44 @@ class InteractiveSolver(CommonSolver):
                     else:
                         if loc in self.visitedLocations:
                             self.removeItemAt(self.locNameInternal2Web(loc.Name))
+
+            # Inventory
+            elif dataType == dataEnum["inventory"]:
+                # Clear collected items if loading from game state.
+                self.collectedItems.clear()
+                self.smbm.resetItems()
+
+                for item, itemData in self.inventoryBitMasks.items():
+                    if item not in Conf.itemsForbidden:
+                        byteIndex = itemData["byteIndex"]
+                        loc = offset + byteIndex
+                        # For two byte values, read little endian value.
+                        if item in ("ETank", "Reserve", "Missile", "Super", "PowerBomb"):
+                            val = currentState[loc] + (currentState[loc + 1] * 256)
+                        else:
+                            val = currentState[loc]
+
+                        if item == "ETank":
+                            tanks = int((val - 99) / 100)
+                            for _ in range(tanks):
+                                self.collectedItems.append(item)
+                                self.smbm.addItem(item)
+                        elif item == "Reserve":
+                            tanks = int(val / 100)
+                            for _ in range(tanks):
+                                self.collectedItems.append(item)
+                                self.smbm.addItem(item)
+                        elif item in ("Missile", "Super", "PowerBomb"):
+                            packs = int(val / 5)
+                            for _ in range(packs):
+                                self.collectedItems.append(item)
+                                self.smbm.addItem(item)
+                        else:
+                            bitMask = itemData["bitMask"]
+                            if val & bitMask != 0:
+                                self.collectedItems.append(item)
+                                self.smbm.addItem(item)
+
             elif dataType == dataEnum["map"]:
                 if self.areaRando or self.bossRando or self.escapeRando:
                     availAPs = set()

--- a/web/backend/tracker.py
+++ b/web/backend/tracker.py
@@ -66,6 +66,7 @@ class Tracker(object):
                     nothingScreens=InteractiveSolver.nothingScreens,
                     doorsScreen=InteractiveSolver.doorsScreen,
                     bossBitMasks=InteractiveSolver.bossBitMasks,
+                    inventoryBitMasks=InteractiveSolver.inventoryBitMasks,
                     apsGraphArea=apsGraphArea)
 
     def trackerWebService(self):

--- a/web/backend/ws.py
+++ b/web/backend/ws.py
@@ -627,7 +627,7 @@ class WS_dump_import(WS):
         jsonData = {"stateDataOffsets": json.loads(self.vars.stateDataOffsets),
                     "currentState": json.loads(self.vars.currentState),
                     "newAP": webAPs[newAP]}
-        if len(jsonData["currentState"]) > 1608 or len(jsonData["stateDataOffsets"]) > 4:
+        if len(jsonData["currentState"]) > 1632 or len(jsonData["stateDataOffsets"]) > 5:
             raiseHttp(400, "Wrong state size", True)
         for key, value in jsonData["stateDataOffsets"].items():
             if len(key) > 1 or type(value) != int:

--- a/web/views/t_js.html
+++ b/web/views/t_js.html
@@ -1,5 +1,5 @@
 // https://stackoverflow.com/questions/16960690/chosen-harvesthq-resize-width-dynamically
-$(document).ready(function(){      
+$(document).ready(function(){
    resizeChosen();
    jQuery(window).on('resize', resizeChosen);
 });
@@ -7,7 +7,7 @@ $(document).ready(function(){
 function resizeChosen() {
    $(".chosen-container").each(function() {
        $(this).attr('style', 'width: 100%');
-   });          
+   });
 }
 
 var loaded = false;
@@ -730,7 +730,7 @@ function updateLocations(jsonData) {
 
             if(! isSeedless(mode)) {
                 // add item
-                addItem(locData["item"]);
+                // addItem(locData["item"]);
             }
         }
 
@@ -753,14 +753,12 @@ function updateLocations(jsonData) {
         }
     }
 
-    if(isSeedless(mode)) {
-        // load items as all locs contain Nothing
-        var collectedItems = jsonData["collectedItems"];
-        for(var i=0; i<collectedItems.length; i++) {
-            var item = collectedItems[i];
-            if(item != "Nothing") {
-                addItem(item);
-            }
+    // load items from response
+    var collectedItems = jsonData["collectedItems"];
+    for(var i=0; i<collectedItems.length; i++) {
+        var item = collectedItems[i];
+        if(item != "Nothing") {
+            addItem(item);
         }
     }
 
@@ -1016,10 +1014,10 @@ window.onload = function(){
   filesInput.addEventListener("change", function(event) {
     var files = event.target.files; // It returns a FileList object
     var file = files[0];
-  
+
     var crc32 = new Crc32();
     var reader = new FileReader();
-  
+
     reader.onload = function(e) {
           // check sfc or smc extention
         var re = /(?:\.([^.]+))?$/;
@@ -1032,7 +1030,7 @@ window.onload = function(){
 
         var re = /((.*)\.[^.]+)?$/;
         var base = re.exec(file.name)[1];
-  
+
         var outFileName = file.name.replace(/\.[^/.]+$/, ".json");
         document.getElementById("fileName").value = file.name;
 
@@ -1119,17 +1117,17 @@ window.onload = function(){
         }
 
         var romData = {};
-  
+
         // locations items
         var addresses = new Array({{=", ".join(str(address) for address in addresses["locations"])}});
-  
+
         var arrayLength = addresses.length;
         for(var i=0; i<arrayLength; i++) {
             romData[addresses[i]] = bytes[addresses[i]];
             romData[addresses[i]+1] = bytes[addresses[i]+1];
             romData[addresses[i]+4] = bytes[addresses[i]+4];
         }
-  
+
         // patches
         var addresses = new Array({{=", ".join(str(address) for address in addresses["patches"])}});
         var arrayLength = addresses.length;
@@ -1156,7 +1154,7 @@ window.onload = function(){
             romData[addresses[i]+10] = bytes[addresses[i]+10];
             romData[addresses[i]+11] = bytes[addresses[i]+11];
         }
-  
+
         // misc
         var addresses = new Array({{=", ".join(str(address) for address in addresses["misc"])}});
         var arrayLength = addresses.length;
@@ -1176,9 +1174,9 @@ window.onload = function(){
         }
 
         romData["romFileName"] = outFileName;
-  
+
         var json = JSON.stringify(romData);
-  
+
         var output = document.getElementById("romJson");
         output.value = json;
 
@@ -1186,7 +1184,7 @@ window.onload = function(){
 
         document.getElementById("startLocationVisibility").style.display = "none";
     }
-  
+
     reader.readAsArrayBuffer(file);
   }, false);
 

--- a/web/views/tracker.html
+++ b/web/views/tracker.html
@@ -4,8 +4,6 @@
 
 <title>Super Metroid VARIA Randomizer Tracker</title>
 
-<script type="text/javascript" src="{{=URL('static', 'js/crc32.js')}}"></script>
-
 <style>
 {{include 'solver_web/t_style.html'}}
 
@@ -393,6 +391,8 @@ var itemsData = undefined;
 var bossData = undefined;
 var mapData = undefined;
 var samusData = undefined;
+let eventsData = undefined;
+let inventoryData = undefined;
 
 // different data that we ask
 var dataEnum = {
@@ -402,7 +402,8 @@ var dataEnum = {
     "samus": 4,
     "items": 5,
     "boss": 6,
-    "events": 7
+    "events": 7,
+    "inventory": 8
 }
 // 1. state:
 // $0998: Game state
@@ -453,6 +454,10 @@ var dataEnum = {
 
 // 7. events
 // $7E:D820..39
+
+// 8. Inventory
+// $7#:09A4..AA
+// $7#:09C4..D6
 var dataToAsk = {
     1: [{"address": "F50998", "size": 0x2},
         {"address": "F505D1", "size": 0x2},
@@ -468,7 +473,9 @@ var dataToAsk = {
         {"address": "F5079B", "size": 0x0a}],
     5: [{"address": "F5D870", "size": 0x20}],
     6: [{"address": "F5D828", "size": 0x8}],
-    7: [{"address": "F5D820", "size": 0x20}]
+    7: [{"address": "F5D820", "size": 0x20}],
+    8: [{"address": "F509A4", "size": 0x6},
+        {"address": "F509C4", "size": 0x12}]
 }
 // use an array listing the data to retrieve, the chain is init at auto tracker start
 var dataToAskChain = [];
@@ -527,6 +534,7 @@ var bossBitMasks = {{response.write(bossBitMasks, escape=False)}};
 var nothingScreens = {{response.write(nothingScreens, escape=False)}};
 var doorsScreen = {{response.write(doorsScreen, escape=False)}};
 var eventsBitMasks = {};
+let inventoryBitMasks = {{response.write(inventoryBitMasks, escape=False)}};
 
 // in js dict keys are strings
 var itemsBitMasks = {
@@ -1361,6 +1369,14 @@ function handleData(data) {
             eventsData = concatArrays(dataEnum.events);
 
             askNextData();
+        } else if (dataToAskChain[dataToAskStep] === dataEnum.inventory) {
+            let duration = Date.now() - transfertStart;
+            console.log(`\u2705 Inventory data received in ${duration}ms`);
+
+            // concatenate all arrays
+            inventoryData = concatArrays(dataEnum.inventory);
+
+            askNextData();
         }
     }
 }
@@ -1540,6 +1556,11 @@ function initDataChain() {
     stateDataOffsets[dataEnum.events] = curOffset;
     curOffset += getDataSize(dataEnum.events);
 
+    // ask for inventory
+    dataToAskChain.push(dataEnum.inventory);
+    stateDataOffsets[dataEnum.inventory] = curOffset;
+    curOffset += getDataSize(dataEnum.inventory);
+
     // ask optional map data
     if(area || boss || doorsRando || hasNothing || escapeRando) {
         dataToAskChain.push(dataEnum.map);
@@ -1614,6 +1635,19 @@ function computeStateBitMasks() {
             var curOffset = stateDataOffsets[dataEnum.events];
             for(var event in eventsBitMasks) {
                 stateBitMasks[curOffset + eventsBitMasks[event]["byteIndex"]] |= eventsBitMasks[event]["bitMask"];
+            }
+        } else if(dataToAskChain[i] === dataEnum.inventory) {
+            let curOffset = stateDataOffsets[dataEnum.inventory];
+            for(let item in inventoryBitMasks) {
+                // If no bit mask defined, this is a two byte quantity (missiles, energy, etc.)
+                if (inventoryBitMasks[item]["bitMask"]) {
+                    stateBitMasks[curOffset + inventoryBitMasks[item]["byteIndex"]] |= inventoryBitMasks[item]["bitMask"];
+                }
+                else {
+                    let bitOffset = curOffset + inventoryBitMasks[item]["byteIndex"];
+                    stateBitMasks[bitOffset] |= 0xFF;
+                    stateBitMasks[bitOffset + 1] |= 0xFF;
+                }
             }
         }
     }
@@ -1733,6 +1767,11 @@ function populateCurrentState() {
             var curOffset = stateDataOffsets[dataEnum.events];
             for(var i=0; i<eventsData.length; i++) {
                 currentState[curOffset + i] = eventsData[i] & stateBitMasks[curOffset + i];
+            }
+        } else if(dataToAskChain[j] === dataEnum.inventory) {
+            let curOffset = stateDataOffsets[dataEnum.inventory];
+            for(let i=0; i<inventoryData.length; i++) {
+                currentState[curOffset + i] = inventoryData[i] & stateBitMasks[curOffset + i];
             }
         }
     }


### PR DESCRIPTION
This changes the inventory population to read from the game memory as part of the current game state instead of populating based on visited locations and their contents.  This makes it so e.g. Archipelago multiworld seeds will work properly where the location contents are items for other people most of the time.

In addition, I also changed the fallback item for such locations (including in race seeds) to be the "NoEnergy" item instead of spring ball as this doesn't mess with the actual inventory, and also doesn't disappear immediately upon viewing like the "Nothing" item does.

I attempted to do this on the current master branch, but the tracker page is crashing there so it's not usable for testing.  I did it on the current production branch instead.