### PR TITLE
Load inventory from game memory data for auto tracking - resolves #111

### DIFF
--- a/rom/romreader.py
+++ b/rom/romreader.py
@@ -338,7 +338,7 @@ class RomReader:
                 loc.itemName = self.items[item]["name"]
             except:
                 # race seeds
-                loc.itemName = "SpringBall"
+                loc.itemName = "NoEnergy"
                 item = '0x0'
 
         return (majorsSplit if majorsSplit != 'FullWithHUD' else 'Full', majorsSplit)

--- a/solver/commonSolver.py
+++ b/solver/commonSolver.py
@@ -292,11 +292,8 @@ class CommonSolver(object):
         # item
         item = loc.itemName
 
-        if self.mode in ['seedless', 'race', 'debug']:
-            # in seedless remove the first nothing found as collectedItems is not ordered
+        if item in self.collectedItems:
             self.collectedItems.remove(item)
-        else:
-            self.collectedItems.pop(locIndex)
 
         # if multiple majors in plando mode, remove it from smbm only when it's the last occurence of it
         if self.smbm.isCountItem(item):

--- a/web/backend/tracker.py
+++ b/web/backend/tracker.py
@@ -72,6 +72,7 @@ class Tracker(object):
                     doorsScreen=InteractiveSolver.doorsScreen,
                     bossBitMasks=InteractiveSolver.bossBitMasks,
                     apsGraphArea=apsGraphArea, flavorPatches=RomReader.flavorPatches,
+                    inventoryBitMasks=InteractiveSolver.inventoryBitMasks,
                     app_files=get_app_files())
 
     def trackerWebService(self):

--- a/web/backend/ws.py
+++ b/web/backend/ws.py
@@ -638,7 +638,7 @@ class WS_dump_import(WS):
         jsonData = {"stateDataOffsets": json.loads(self.vars.stateDataOffsets),
                     "currentState": json.loads(self.vars.currentState),
                     "newAP": webAPs[newAP]}
-        if len(jsonData["currentState"]) > 1608 or len(jsonData["stateDataOffsets"]) > 4:
+        if len(jsonData["currentState"]) > 1632 or len(jsonData["stateDataOffsets"]) > 5:
             raiseHttp(400, "Wrong state size", True)
         for key, value in jsonData["stateDataOffsets"].items():
             if len(key) > 1 or type(value) != int:

--- a/web/views/tracker.html
+++ b/web/views/tracker.html
@@ -4,8 +4,6 @@
 
 <title>Super Metroid VARIA Randomizer Tracker</title>
 
-<script type="text/javascript" src="{{=URL('static', 'js/crc32.js')}}"></script>
-
 <style>
 {{include 'solver_web/t_style.html'}}
 
@@ -351,6 +349,8 @@ var itemsData = undefined;
 var bossData = undefined;
 var mapData = undefined;
 var samusData = undefined;
+let eventsData = undefined;
+let inventoryData = undefined;
 
 // different data that we ask
 var dataEnum = {
@@ -360,7 +360,8 @@ var dataEnum = {
     "samus": 4,
     "items": 5,
     "boss": 6,
-    "events": 7
+    "events": 7,
+    "inventory": 8
 }
 // 1. state:
 // $0998: Game state
@@ -411,6 +412,10 @@ var dataEnum = {
 
 // 7. events
 // $7E:D820..39
+
+// 8. Inventory
+// $7#:09A4..AA
+// $7#:09C4..D6
 var dataToAsk = {
     1: [{"address": "F50998", "size": 0x2},
         {"address": "F505D1", "size": 0x2},
@@ -426,7 +431,9 @@ var dataToAsk = {
         {"address": "F5079B", "size": 0x0a}],
     5: [{"address": "F5D870", "size": 0x20}],
     6: [{"address": "F5D828", "size": 0x8}],
-    7: [{"address": "F5D820", "size": 0x20}]
+    7: [{"address": "F5D820", "size": 0x20}],
+    8: [{"address": "F509A4", "size": 0x6},
+        {"address": "F509C4", "size": 0x12}]
 }
 // use an array listing the data to retrieve, the chain is init at auto tracker start
 var dataToAskChain = [];
@@ -485,6 +492,7 @@ var bossBitMasks = {{response.write(bossBitMasks, escape=False)}};
 var nothingScreens = {{response.write(nothingScreens, escape=False)}};
 var doorsScreen = {{response.write(doorsScreen, escape=False)}};
 var eventsBitMasks = {};
+let inventoryBitMasks = {{response.write(inventoryBitMasks, escape=False)}};
 
 // in js dict keys are strings
 var itemsBitMasks = {
@@ -1571,6 +1579,14 @@ function handleData(data) {
             eventsData = concatArrays(dataEnum.events);
 
             askNextData();
+        } else if (dataToAskChain[dataToAskStep] === dataEnum.inventory) {
+            let duration = Date.now() - transfertStart;
+            console.log(`\u2705 Inventory data received in ${duration}ms`);
+
+            // concatenate all arrays
+            inventoryData = concatArrays(dataEnum.inventory);
+
+            askNextData();
         }
     }
 }
@@ -1682,6 +1698,11 @@ function initDataChain() {
     stateDataOffsets[dataEnum.events] = curOffset;
     curOffset += getDataSize(dataEnum.events);
 
+    // ask for inventory
+    dataToAskChain.push(dataEnum.inventory);
+    stateDataOffsets[dataEnum.inventory] = curOffset;
+    curOffset += getDataSize(dataEnum.inventory);
+
     // ask optional map data
     if(area || boss || doorsRando || hasNothing || escapeRando) {
         dataToAskChain.push(dataEnum.map);
@@ -1756,6 +1777,19 @@ function computeStateBitMasks() {
             var curOffset = stateDataOffsets[dataEnum.events];
             for(var event in eventsBitMasks) {
                 stateBitMasks[curOffset + eventsBitMasks[event]["byteIndex"]] |= eventsBitMasks[event]["bitMask"];
+            }
+        } else if(dataToAskChain[i] === dataEnum.inventory) {
+            let curOffset = stateDataOffsets[dataEnum.inventory];
+            for(let item in inventoryBitMasks) {
+                // If no bit mask defined, this is a two byte quantity (missiles, energy, etc.)
+                if (inventoryBitMasks[item]["bitMask"]) {
+                    stateBitMasks[curOffset + inventoryBitMasks[item]["byteIndex"]] |= inventoryBitMasks[item]["bitMask"];
+                }
+                else {
+                    let bitOffset = curOffset + inventoryBitMasks[item]["byteIndex"];
+                    stateBitMasks[bitOffset] |= 0xFF;
+                    stateBitMasks[bitOffset + 1] |= 0xFF;
+                }
             }
         }
     }
@@ -1872,6 +1906,11 @@ function populateCurrentState() {
             var curOffset = stateDataOffsets[dataEnum.events];
             for(var i=0; i<eventsData.length; i++) {
                 currentState[curOffset + i] = eventsData[i] & stateBitMasks[curOffset + i];
+            }
+        } else if(dataToAskChain[j] === dataEnum.inventory) {
+            let curOffset = stateDataOffsets[dataEnum.inventory];
+            for(let i=0; i<inventoryData.length; i++) {
+                currentState[curOffset + i] = inventoryData[i] & stateBitMasks[curOffset + i];
             }
         }
     }


### PR DESCRIPTION
I ended up making a new branch, so the previous PR closed.

This changes the inventory population to read from the game memory as part of the current game state instead of populating based on visited locations and their contents.  This makes it so e.g. Archipelago multiworld seeds will work properly where the location contents are items for other people most of the time.

In addition, I also changed the fallback item for such locations to be the "NoEnergy" item instead of spring ball.  In a MW seed, the item at most locations is a MW item for another player statistically.  This item is not recognized by the tracker, so it was falling back to putting "SpringBall" at every location which doesn't make sense.  Initially I tried the "Nothing" item, but the location is marked as visited as soon as it is viewed at all, even if e.g. it's out of reach and the player hasn't actually gotten the item yet.  I changed it to "NoEnergy" instead, so it wouldn't affect inventory.