### PR TITLE
doorsRando can now be set for seedless roms

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -192,7 +192,7 @@ if __name__ == "__main__":
     parser.add_argument('--fill', help="in plando load all the source seed locations/transitions as a base (used in interactive mode)",
                         dest="fill", action='store_true')
     parser.add_argument('--startLocation', help="in plando/seedless: the start location", dest="startLocation", default="Landing Site")
-    parser.add_argument('--doorsRando', help="in seedless: door randomization", dest="doorsRando", action=argparse.BooleanOptionalAction)
+    parser.add_argument('--doorsRando', help="in seedless: door randomization", dest="doorsRando", action='store_true')
     parser.add_argument('--minorQty', help="rando plando  (used in interactive mode)",
                         dest="minorQty", nargs="?", default=None, choices=[str(i) for i in range(0,101)])
     parser.add_argument('--energyQty', help="rando plando  (used in interactive mode)",

--- a/solver.py
+++ b/solver.py
@@ -22,7 +22,11 @@ def interactiveSolver(args):
             sys.exit(1)
 
         solver = InteractiveSolver(args.shm, args.logic)
-        solver.initialize(args.mode, args.romFileName, args.presetFileName, magic=args.raceMagic, fill=args.fill, startLocation=args.startLocation)
+        extraSettings = {
+            'startLocation': args.startLocation,
+            'doorsRando': args.doorsRando,
+        }
+        solver.initialize(args.mode, args.romFileName, args.presetFileName, magic=args.raceMagic, fill=args.fill, extraSettings=extraSettings)
     else:
         # iterate
         params = {}
@@ -188,6 +192,7 @@ if __name__ == "__main__":
     parser.add_argument('--fill', help="in plando load all the source seed locations/transitions as a base (used in interactive mode)",
                         dest="fill", action='store_true')
     parser.add_argument('--startLocation', help="in plando/seedless: the start location", dest="startLocation", default="Landing Site")
+    parser.add_argument('--doorsRando', help="in seedless: door randomization", dest="doorsRando", action=argparse.BooleanOptionalAction)
     parser.add_argument('--minorQty', help="rando plando  (used in interactive mode)",
                         dest="minorQty", nargs="?", default=None, choices=[str(i) for i in range(0,101)])
     parser.add_argument('--energyQty', help="rando plando  (used in interactive mode)",

--- a/solver/commonSolver.py
+++ b/solver/commonSolver.py
@@ -17,7 +17,7 @@ from rom.flavor import RomFlavor
 from graph.location import define_location
 
 class CommonSolver(object):
-    def loadRom(self, rom, interactive=False, magic=None, startLocation=None):
+    def loadRom(self, rom, interactive=False, magic=None, extraSettings=None):
         self.scavengerOrder = []
         self.plandoScavengerOrder = []
         self.additionalETanks = 0
@@ -33,9 +33,9 @@ class CommonSolver(object):
             self.bossRando = True
             self.escapeRando = False
             self.escapeTimer = "03:00"
-            self.startLocation = startLocation
-            RomPatches.setDefaultPatches(startLocation)
-            self.startArea = getAccessPoint(startLocation).Start['solveArea']
+            self.startLocation = extraSettings.get('startLocation')
+            RomPatches.setDefaultPatches(self.startLocation)
+            self.startArea = getAccessPoint(self.startLocation).Start['solveArea']
             # in seedless load all the vanilla transitions
             self.areaTransitions = vanillaTransitions[:]
             self.bossTransitions = vanillaBossesTransitions[:]
@@ -47,8 +47,8 @@ class CommonSolver(object):
             for loc in self.locations:
                 loc.itemName = 'Nothing'
             # set doors related to default patches
-            DoorsManager.setDoorsColor()
-            self.doorsRando = False
+            self.doorsRando = extraSettings.get('doorsRando')
+            DoorsManager.setDoorsColor(seedless=self.doorsRando)
             self.hasNothing = False
             self.objectives.setVanilla()
             self.tourian = 'Vanilla'

--- a/solver/interactiveSolver.py
+++ b/solver/interactiveSolver.py
@@ -77,7 +77,7 @@ class InteractiveSolver(CommonSolver):
         self.shm.writeMsgJson(state.get())
         self.shm.finish(False)
 
-    def initialize(self, mode, rom, presetFileName, magic, fill, startLocation):
+    def initialize(self, mode, rom, presetFileName, magic, fill, extraSettings):
         # load rom and preset, return first state
         self.debug = mode == "debug"
         self.mode = mode
@@ -91,7 +91,7 @@ class InteractiveSolver(CommonSolver):
         self.presetFileName = presetFileName
         self.loadPreset(self.presetFileName)
 
-        self.loadRom(rom, interactive=True, magic=magic, startLocation=startLocation)
+        self.loadRom(rom, interactive=True, magic=magic, extraSettings=extraSettings)
         # in plando/tracker always consider that we're doing full
         self.majorsSplit = 'Full'
 

--- a/utils/doorsmanager.py
+++ b/utils/doorsmanager.py
@@ -115,6 +115,7 @@ class Door(object):
         # custom start location, area, patches can force doors to blue
         self.setColor('blue')
         self.forced = True
+        self.hidden = False
 
     def setColor(self, color):
         self.color = color
@@ -337,7 +338,10 @@ class DoorsManager():
         return DoorsManager.doors[doorName].traverse(smbm)
 
     @staticmethod
-    def setDoorsColor():
+    def setDoorsColor(seedless=False):
+        if seedless:
+            for door in DoorsManager.doors.values():
+                door.hide()
         # depending on loaded patches, force some doors to blue, excluding them from randomization
         if RomPatches.has(RomPatches.BlueBrinstarBlueDoor):
             DoorsManager.doors['ConstructionZoneRight'].forceBlue()

--- a/web/backend/ws.py
+++ b/web/backend/ws.py
@@ -324,6 +324,7 @@ class WS_common_init(WS):
 
         preset = self.vars.preset
         presetFileName = '{}/{}.json'.format(getPresetDir(preset), preset)
+        doorsRando = self.vars.doorsRando == 'true'
 
         self.session["logic"] = logic
         self.session["seed"] = seed
@@ -333,9 +334,9 @@ class WS_common_init(WS):
 
         fill = self.vars.fill == "true"
 
-        return self.callSolverInit(jsonRomFileName, presetFileName, preset, seed, logic, mode, fill, startLocation)
+        return self.callSolverInit(jsonRomFileName, presetFileName, preset, seed, logic, mode, fill, startLocation, doorsRando)
 
-    def callSolverInit(self, jsonRomFileName, presetFileName, preset, romFileName, logic, mode, fill, startLocation):
+    def callSolverInit(self, jsonRomFileName, presetFileName, preset, romFileName, logic, mode, fill, startLocation, doorsRando):
         shm = SHM()
         params = [
             getPythonExec(),  os.path.expanduser("~/RandomMetroidSolver/solver.py"),
@@ -356,6 +357,8 @@ class WS_common_init(WS):
 
         if startLocation != None:
             params += ['--startLocation', startLocation]
+        if doorsRando:
+            params.append('--doorsRando')
 
         print("before calling isolver: {}".format(params))
         start = datetime.now()
@@ -601,7 +604,7 @@ class WS_door_replace(WS):
         if self.doorName not in DoorsManager.doors.keys():
             raiseHttp(400, "Wrong value for doorName", True)
         self.newColor = self.vars.newColor
-        if self.newColor not in ["red", "green", "yellow", "grey", "wave", "spazer", "plasma", "ice"]:
+        if self.newColor not in ["red", "green", "yellow", "grey", "wave", "spazer", "plasma", "ice", "blue"]:
             raiseHttp(400, "Wrong value for newColor", True)
 
     def action(self):

--- a/web/views/plando.html
+++ b/web/views/plando.html
@@ -473,6 +473,7 @@ function onloadHook() {
 
   document.getElementById("startLocationVisibility").style.display = "none";
   document.getElementById("logicVisibility").style.display = "none";
+  document.getElementById("doorsRandoVisibility").style.display = "none";
 
   var vcrFileInput = document.getElementById("vcrFile");
   vcrFileInput.addEventListener("change", function(event){

--- a/web/views/t_js.html
+++ b/web/views/t_js.html
@@ -494,6 +494,7 @@ window.onload = function(){
 
         document.getElementById("startLocationVisibility").style.display = "none";
         document.getElementById("logicVisibility").style.display = "none";
+        document.getElementById("doorsRandoVisibility").style.display = "none";
     }
   
     reader.readAsArrayBuffer(file);
@@ -619,6 +620,7 @@ function initSolver() {
             fileName: document.getElementById("fileName").value,
             fill: document.getElementById("fillPlando").checked,
             startLocation: document.getElementById("startLocation").value,
+            doorsRando: document.getElementById("doorsRando").checked,
             mode: mode, logic: logic}, "download");
 
   hidePopup();
@@ -777,6 +779,7 @@ function clearInputSeed() {
   document.getElementById("fileName").value = "";
   if(mode != "plando") {
     document.getElementById("startLocationVisibility").style.display = "table-row";
+    document.getElementById("doorsRandoVisibility").style.display = "table-row";
     document.getElementById("logicVisibility").style.display = "table-row";
   }
 }

--- a/web/views/t_main.html
+++ b/web/views/t_main.html
@@ -32,6 +32,10 @@
         <td>Logic:</td>
         <td colspan=2>{{=SELECT(["vanilla", "mirror"], **dict(_name="logic", _id="logic", value=curSession["logic"], _class="filldropdown"))}}</td>
       </tr>
+      <tr id="doorsRandoVisibility">
+        <td>Door randomization:</td>
+        <td><input id="doorsRando" name="doorsRando" type="checkbox"></td>
+      </tr>
       <tr><td colspan=3 class="blankLastRow"></td></tr>
     </table>
     <table>


### PR DESCRIPTION
This adds a --doorsRando option to the solver and a corresponding checkmark to the tracker so that all doors can be initialized as hidden for seedless door rando maps. It touches a lot of code I know little about so I wanted to do a PR. I tested doorRando in the tracker and generating seeds from the randomizer and planodmizer.