### PR TITLE
Fix events data crash when starting autotracking

### DIFF
--- a/solver/interactiveSolver.py
+++ b/solver/interactiveSolver.py
@@ -1052,6 +1052,9 @@ class InteractiveSolver(CommonSolver):
                         continue
                     byteIndex = eventData["byteIndex"]
                     bitMask = eventData["bitMask"]
+                    # Check for bad offset/byte index.
+                    if offset + byteIndex >= len(currentState):
+                        continue
                     goalName = goalsList[i]
                     goalCompleted = goalsCompleted[i]
                     if currentState[offset + byteIndex] & bitMask != 0:


### PR DESCRIPTION
This crash occurs when starting autotracking and reading events data from the ROM.  I'm not sure why the state data is not correct here (it seems to be missing the events data) but it may be related to some difference between the Archipelago ROM vs the VARIA ROM changes.  This at least prevents that crash and lets autotracking work correctly for AP ROMs again.