### PR TITLE
Set any missing params to default for randomizer and display an error

### DIFF
--- a/web/backend/randomizer.py
+++ b/web/backend/randomizer.py
@@ -215,7 +215,7 @@ class Randomizer(object):
                   'morphPlacement', 'energyQty', 'startLocation', 'gravityBehaviour',
                   'areaRandomization', 'logic']
         others = ['complexity', 'paramsFileTarget', 'seed', 'preset', 'maxDifficulty', 'objective', 'nbObjectivesRequired']
-        validateWebServiceParams(self.request, switchs, quantities, multis, others, isJson=True)
+        errors = validateWebServiceParams(self.request, switchs, quantities, multis, others, isJson=True)
 
         # randomize
         db = DB()
@@ -301,13 +301,12 @@ class Randomizer(object):
             with open(jsonFileName) as jsonFile:
                 locsItems = json.load(jsonFile)
 
-            # check if an info message has been returned
-            msg = ''
-            if len(locsItems['errorMsg']) > 0:
-                msg = locsItems['errorMsg']
-                if msg[0] == '\n':
-                    msg = msg[1:]
-                locsItems['errorMsg'] = msg.replace('\n', '<br/>')
+            # update errorMsg with additional errors from default params
+            errors = errors + locsItems['errorMsg'].split('\n')
+            errors = [e for e in errors if e] # remove empty strings
+
+            msg = '\n'.join(errors)
+            locsItems['errorMsg'] = msg.replace('\n', '<br/>')
 
             db.addRandoResult(id, ret, duration, msg)
 

--- a/web/backend/utils.py
+++ b/web/backend/utils.py
@@ -4,7 +4,7 @@ from rom.rom import snes_to_pc
 from rom.romreader import RomReader
 from rom.addresses import Addresses
 from utils.doorsmanager import DoorsManager
-from utils.utils import getDefaultMultiValues, getPresetDir, removeChars
+from utils.utils import getDefaultMultiValues, getPresetDir, removeChars, getRandomizerDefaultParameters
 from utils.parameters import Knows, isKnows, Controller, isButton
 from utils.objectives import Objectives
 from logic.logic import Logic
@@ -169,10 +169,13 @@ def getFloat(request, param, isJson=False):
 
 def validateWebServiceParams(request, switchs, quantities, multis, others, isJson=False):
     parameters = switchs + quantities + multis + others
+    defaultParameters = getRandomizerDefaultParameters()
+    errors = []
 
     for param in parameters:
         if request.vars[param] is None:
-            raiseHttp(400, "Missing parameter: {}".format(param), isJson)
+            request.vars[param] = defaultParameters[param]
+            errors.append(f'Missing param set: {param}={defaultParameters[param]}')
 
     # switchs
     for switch in switchs:
@@ -332,6 +335,8 @@ def validateWebServiceParams(request, switchs, quantities, multis, others, isJso
         value = request.vars.nbObjectivesRequired
         if value not in ("off", "random", *numbers):
             raiseHttp(400, f"Wrong value for nbObjectivesRequired {value}", isJson)
+
+    return errors
 
 def getCustomMapping(controlMapping):
     if len(controlMapping) == 0:


### PR DESCRIPTION
I tested this by adding `delete dataDict.revealMap` to line 1070 of `web/views/randomizer.html`. Screenshot below shows how it integrates with other warning messages. I don't think it'd be possible to get missing params like this from the front end, but if it happens the user will be warned.  

![image](https://github.com/theonlydude/RandomMetroidSolver/assets/379151/66429c6a-1e99-4a6f-a1a2-e14a4e229e4a)
