### PR TITLE
Avoid unnecessary deep copies to improve generation speed

### DIFF
--- a/logic/smboolmanager.py
+++ b/logic/smboolmanager.py
@@ -1,5 +1,7 @@
 # object to handle the smbools and optimize them
 
+import copy
+
 from logic.cache import Cache
 from logic.smbool import SMBool, smboolFalse
 from logic.helpers import Bosses
@@ -225,6 +227,17 @@ class SMBoolManager(object):
             return SMBool(True, difficulty, items = [items])
         else:
             return smboolFalse
+
+    def __deepcopy__(self, memo=None):
+        cls = self.__class__
+        cp = cls.__new__(cls)
+        if memo is None:
+            memo = {}
+        memo[id(self)] = cp
+        for k, v in self.__dict__.items():
+            setattr(cp, k, copy.deepcopy(v, memo))
+        return cp
+
 
 class SMBoolManagerPlando(SMBoolManager):
     def __init__(self):

--- a/utils/objectives.py
+++ b/utils/objectives.py
@@ -1512,4 +1512,15 @@ class Objectives(object):
         rom.writeWord(0xAE5B)
         rom.writeWord(0x9698)
 
+    def __deepcopy__(self, memo=None):
+        cls = self.__class__
+        cp = cls.__new__(cls)
+        if memo is None:
+            memo = {}
+        memo[id(self.graph)] = self.graph
+        for k, v in self.__dict__.items():
+            setattr(cp, k, copy.deepcopy(v, memo))
+        return cp
+
+
 objective_mapicons = [ObjectiveMapIcon(i) for i in range(Objectives.maxActiveGoals)]


### PR DESCRIPTION
In Archipelago, Super Metroid's `copy_mixin` function showed up in profile results as 145s cumulative time, out of 639s (73 players). Most of that time is in `deepcopy` and my analysis showed the majority was spent copying the fields `helpers` and `objectives`, of which the latter breaks down further into `goals` and `graph`.

`helpers` just keeps a reference to the `smbm`, so we don't need to create another copy while we're copying, and `graph` is remarked as being something that doesn't change. As such, we can avoid making copies of those; `helpers` can point back at the new copy, and `graph` can be the same object.

Results:
* while profiling: 528s -> 412s (~22% improved)
* with spoiler=1: 213s -> 182s (~15% improved)
* with spoiler=3: 837s -> 742s (~11% improved)

---

I wrote and tested this in Archipelago ([PR](https://github.com/ArchipelagoMW/Archipelago/pull/4130)) without a ROM file, so please confirm that this works as expected here, especially as I did not confirm that the graph referenced by Objectives is not modified somewhere deeply hidden in the code, but since this did not break AP generation with the base settings I believe it works right.